### PR TITLE
fix: resolve macOS permission issues and push-to-talk key release

### DIFF
--- a/src-tauri/Entitlements.plist
+++ b/src-tauri/Entitlements.plist
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <!-- Microphone access (audio capture via cpal) -->
+  <key>com.apple.security.device.audio-input</key>
+  <true/>
+  <!-- Allow Apple Events for paste simulation -->
+  <key>com.apple.security.automation.apple-events</key>
+  <true/>
+</dict>
+</plist>

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -251,8 +251,6 @@ pub async fn set_active_model(
 pub async fn check_accessibility() -> Result<bool, String> {
     #[cfg(target_os = "macos")]
     {
-        use std::os::raw::c_void;
-
         #[link(name = "ApplicationServices", kind = "framework")]
         extern "C" {
             fn AXIsProcessTrusted() -> u8;
@@ -319,6 +317,53 @@ pub async fn request_accessibility() -> Result<bool, String> {
     #[cfg(not(target_os = "macos"))]
     {
         Ok(true)
+    }
+}
+
+// ── Microphone Permission ────────────────────────────────────────────────
+
+#[tauri::command]
+pub async fn check_microphone() -> Result<String, String> {
+    #[cfg(target_os = "macos")]
+    {
+        let status = crate::check_microphone_permission();
+        let label = match status {
+            0 => "not_determined",
+            1 => "denied",
+            2 => "restricted",
+            3 => "authorized",
+            _ => "unknown",
+        };
+        Ok(label.to_string())
+    }
+
+    #[cfg(not(target_os = "macos"))]
+    {
+        Ok("authorized".to_string())
+    }
+}
+
+#[tauri::command]
+pub async fn request_microphone() -> Result<String, String> {
+    #[cfg(target_os = "macos")]
+    {
+        crate::request_microphone_permission();
+        // Give the system a moment to show the dialog, then re-check
+        tokio::time::sleep(std::time::Duration::from_millis(500)).await;
+        let status = crate::check_microphone_permission();
+        let label = match status {
+            0 => "not_determined",
+            1 => "denied",
+            2 => "restricted",
+            3 => "authorized",
+            _ => "unknown",
+        };
+        Ok(label.to_string())
+    }
+
+    #[cfg(not(target_os = "macos"))]
+    {
+        Ok("authorized".to_string())
     }
 }
 

--- a/src-tauri/src/hotkey/manager.rs
+++ b/src-tauri/src/hotkey/manager.rs
@@ -1,6 +1,7 @@
 use tauri::{App, Emitter, Manager};
 use tauri_plugin_global_shortcut::{GlobalShortcutExt, ShortcutState};
 
+use crate::config::settings::RecordingMode;
 use crate::AppState;
 
 pub fn register_hotkey(app: &mut App) -> Result<(), Box<dyn std::error::Error>> {
@@ -13,18 +14,36 @@ pub fn register_hotkey(app: &mut App) -> Result<(), Box<dyn std::error::Error>> 
     let handle = app.handle().clone();
 
     app.global_shortcut().on_shortcut(hotkey.as_str(), move |_app, _shortcut, event| {
-        if event.state == ShortcutState::Pressed {
-            let state = handle.state::<AppState>();
-            let is_recording = state.recording.lock().unwrap().is_some();
+        let state = handle.state::<AppState>();
+        let is_recording = state.recording.lock().unwrap().is_some();
+        let mode = state.settings.lock().unwrap().recording_mode.clone();
 
-            if is_recording {
-                let _ = handle.emit("hotkey-stop", ());
-            } else {
-                // Capture the frontmost app/window now — before any overlay appears
-                let target = crate::output::paste::get_frontmost_target();
-                log::info!("Hotkey captured target_focus = {:?}", target);
-                *state.target_focus.lock().unwrap() = target;
-                let _ = handle.emit("hotkey-start", ());
+        match event.state {
+            ShortcutState::Pressed => {
+                if matches!(mode, RecordingMode::PushToTalk) {
+                    if !is_recording {
+                        let target = crate::output::paste::get_frontmost_target();
+                        log::info!("Hotkey captured target_focus = {:?}", target);
+                        *state.target_focus.lock().unwrap() = target;
+                        let _ = handle.emit("hotkey-start", ());
+                    }
+                } else {
+                    // Toggle mode: press to start, press again to stop
+                    if is_recording {
+                        let _ = handle.emit("hotkey-stop", ());
+                    } else {
+                        let target = crate::output::paste::get_frontmost_target();
+                        log::info!("Hotkey captured target_focus = {:?}", target);
+                        *state.target_focus.lock().unwrap() = target;
+                        let _ = handle.emit("hotkey-start", ());
+                    }
+                }
+            }
+            ShortcutState::Released => {
+                if matches!(mode, RecordingMode::PushToTalk) && is_recording {
+                    log::info!("Push-to-talk key released, stopping recording");
+                    let _ = handle.emit("hotkey-stop", ());
+                }
             }
         }
     })?;
@@ -46,16 +65,33 @@ pub fn re_register_hotkey(
     let handle = app.clone();
     shortcuts
         .on_shortcut(new_hotkey, move |_app, _shortcut, event| {
-            if event.state == ShortcutState::Pressed {
-                let state = handle.state::<AppState>();
-                let is_recording = state.recording.lock().unwrap().is_some();
+            let state = handle.state::<AppState>();
+            let is_recording = state.recording.lock().unwrap().is_some();
+            let mode = state.settings.lock().unwrap().recording_mode.clone();
 
-                if is_recording {
-                    let _ = handle.emit("hotkey-stop", ());
-                } else {
-                    let target = crate::output::paste::get_frontmost_target();
-                    *state.target_focus.lock().unwrap() = target;
-                    let _ = handle.emit("hotkey-start", ());
+            match event.state {
+                ShortcutState::Pressed => {
+                    if matches!(mode, RecordingMode::PushToTalk) {
+                        if !is_recording {
+                            let target = crate::output::paste::get_frontmost_target();
+                            *state.target_focus.lock().unwrap() = target;
+                            let _ = handle.emit("hotkey-start", ());
+                        }
+                    } else {
+                        if is_recording {
+                            let _ = handle.emit("hotkey-stop", ());
+                        } else {
+                            let target = crate::output::paste::get_frontmost_target();
+                            *state.target_focus.lock().unwrap() = target;
+                            let _ = handle.emit("hotkey-start", ());
+                        }
+                    }
+                }
+                ShortcutState::Released => {
+                    if matches!(mode, RecordingMode::PushToTalk) && is_recording {
+                        log::info!("Push-to-talk key released, stopping recording");
+                        let _ = handle.emit("hotkey-stop", ());
+                    }
                 }
             }
         })

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -22,13 +22,16 @@ pub struct AppState {
 }
 
 /// macOS: Checks if the app has Accessibility permission.
-/// If not, opens the System Settings prompt so the user can grant it.
+/// Only opens the System Settings prompt if the permission is NOT already granted.
+/// This avoids the repeated prompt that macOS shows when calling
+/// AXIsProcessTrustedWithOptions with kAXTrustedCheckOptionPrompt=true on every launch.
 #[cfg(target_os = "macos")]
 fn request_accessibility_if_needed() {
     use std::os::raw::c_void;
 
     #[link(name = "ApplicationServices", kind = "framework")]
     extern "C" {
+        fn AXIsProcessTrusted() -> u8;
         fn AXIsProcessTrustedWithOptions(options: *const c_void) -> u8;
     }
 
@@ -54,6 +57,20 @@ fn request_accessibility_if_needed() {
     }
 
     unsafe {
+        // First: check WITHOUT prompting
+        let already_trusted = AXIsProcessTrusted() != 0;
+        log::info!(
+            "[permissions] Accessibility: already_trusted = {}",
+            already_trusted
+        );
+
+        if already_trusted {
+            // Permission is cached and valid — no need to prompt
+            return;
+        }
+
+        // Not trusted — show the prompt once so the user can grant it
+        log::info!("[permissions] Accessibility not granted, showing system prompt");
         let keys = [kAXTrustedCheckOptionPrompt];
         let values = [kCFBooleanTrue];
         let options = CFDictionaryCreate(
@@ -64,10 +81,85 @@ fn request_accessibility_if_needed() {
             &kCFTypeDictionaryKeyCallBacks as *const _ as *const c_void,
             &kCFTypeDictionaryValueCallBacks as *const _ as *const c_void,
         );
-        let trusted = AXIsProcessTrustedWithOptions(options);
+        let _trusted = AXIsProcessTrustedWithOptions(options);
         CFRelease(options as *mut c_void);
-        log::info!("AXIsProcessTrusted = {}", trusted != 0);
     }
+}
+
+/// macOS: Check microphone authorization status via swift subprocess.
+/// The AVFoundation Objective-C FFI from Rust has symbol resolution issues with
+/// AVMediaTypeAudio, so we shell out to swift which handles it natively.
+/// Returns: 0 = not determined, 1 = denied, 2 = restricted, 3 = authorized
+#[cfg(target_os = "macos")]
+pub fn check_microphone_permission() -> i32 {
+    let output = std::process::Command::new("swift")
+        .args([
+            "-e",
+            "import AVFoundation; print(AVCaptureDevice.authorizationStatus(for: .audio).rawValue)",
+        ])
+        .output();
+
+    match output {
+        Ok(out) if out.status.success() => {
+            let status = String::from_utf8_lossy(&out.stdout)
+                .trim()
+                .parse::<i32>()
+                .unwrap_or(-1);
+            let label = match status {
+                0 => "not_determined",
+                1 => "denied",
+                2 => "restricted",
+                3 => "authorized",
+                _ => "unknown",
+            };
+            log::info!("[permissions] Microphone: status = {} ({})", status, label);
+            status
+        }
+        Ok(out) => {
+            log::warn!(
+                "[permissions] swift mic check failed: {}",
+                String::from_utf8_lossy(&out.stderr)
+            );
+            -1
+        }
+        Err(e) => {
+            log::warn!("[permissions] failed to run swift: {}", e);
+            -1
+        }
+    }
+}
+
+/// macOS: Request microphone permission via swift subprocess.
+/// Triggers the system permission dialog if status is "not determined".
+/// Blocks for up to 30 seconds waiting for user response.
+#[cfg(target_os = "macos")]
+fn request_microphone_permission() {
+    log::info!("[permissions] Requesting microphone access via AVCaptureDevice");
+    std::thread::spawn(|| {
+        let output = std::process::Command::new("swift")
+            .args([
+                "-e",
+                concat!(
+                    "import AVFoundation; import Foundation; ",
+                    "let sem = DispatchSemaphore(value: 0); ",
+                    "AVCaptureDevice.requestAccess(for: .audio) { granted in ",
+                    "  print(granted ? 3 : 1); sem.signal() ",
+                    "}; ",
+                    "_ = sem.wait(timeout: .now() + 30)"
+                ),
+            ])
+            .output();
+
+        match output {
+            Ok(out) => {
+                let result = String::from_utf8_lossy(&out.stdout).trim().to_string();
+                log::info!("[permissions] Microphone request result: {}", result);
+            }
+            Err(e) => {
+                log::warn!("[permissions] Failed to request mic permission: {}", e);
+            }
+        }
+    });
 }
 
 /// Linux: Writes a PID file and creates a named pipe (FIFO) that listens for
@@ -205,7 +297,33 @@ pub fn run() {
         })
         .setup(|app| {
             #[cfg(target_os = "macos")]
-            request_accessibility_if_needed();
+            {
+                // Log bundle ID for debugging permission identity
+                if let Ok(output) = std::process::Command::new("defaults")
+                    .args(["read", "/proc/curproc/../Info", "CFBundleIdentifier"])
+                    .output()
+                {
+                    log::info!(
+                        "[permissions] Bundle ID from defaults: {}",
+                        String::from_utf8_lossy(&output.stdout).trim()
+                    );
+                }
+                log::info!(
+                    "[permissions] PID = {}, executable = {:?}",
+                    std::process::id(),
+                    std::env::current_exe().ok()
+                );
+
+                // Check + prompt for accessibility only if not already granted
+                request_accessibility_if_needed();
+
+                // Check microphone permission; request if not yet determined
+                let mic_status = check_microphone_permission();
+                if mic_status == 0 {
+                    // Not determined — trigger the system prompt
+                    request_microphone_permission();
+                }
+            }
 
             tray::setup_tray(&app.handle())?;
 
@@ -258,6 +376,8 @@ pub fn run() {
             set_active_model,
             check_accessibility,
             request_accessibility,
+            check_microphone,
+            request_microphone,
             get_launch_at_login,
             set_launch_at_login,
             get_recent_logs,

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -54,7 +54,8 @@
     ],
     "macOS": {
       "minimumSystemVersion": "12.0",
-      "infoPlist": "Info.plist"
+      "infoPlist": "Info.plist",
+      "entitlements": "Entitlements.plist"
     },
     "windows": {
       "digestAlgorithm": "sha256",

--- a/src/components/Settings.tsx
+++ b/src/components/Settings.tsx
@@ -21,6 +21,7 @@ export function Settings() {
   const [saved, setSaved] = useState(false);
   const [launchAtLogin, setLaunchAtLogin] = useState(false);
   const [accessibilityGranted, setAccessibilityGranted] = useState<boolean | null>(null);
+  const [micStatus, setMicStatus] = useState<string | null>(null);
   const [lastError, setLastError] = useState<string | null>(null);
   const [logsCopied, setLogsCopied] = useState(false);
 
@@ -28,6 +29,7 @@ export function Settings() {
     invoke<Settings>("get_settings").then(setSettings);
     invoke<boolean>("get_launch_at_login").then(setLaunchAtLogin).catch(() => {});
     invoke<boolean>("check_accessibility").then(setAccessibilityGranted).catch(() => {});
+    invoke<string>("check_microphone").then(setMicStatus).catch(() => {});
   }, []);
 
   // Listen for backend errors
@@ -54,10 +56,11 @@ export function Settings() {
     );
   };
 
-  // Re-check accessibility when window regains focus (user may have toggled it in System Settings)
+  // Re-check permissions when window regains focus (user may have toggled them in System Settings)
   useEffect(() => {
     const onFocus = () => {
       invoke<boolean>("check_accessibility").then(setAccessibilityGranted).catch(() => {});
+      invoke<string>("check_microphone").then(setMicStatus).catch(() => {});
     };
     window.addEventListener("focus", onFocus);
     return () => window.removeEventListener("focus", onFocus);
@@ -104,6 +107,33 @@ export function Settings() {
             }}
           >
             Open System Settings
+          </button>
+        </div>
+      )}
+
+      {micStatus && micStatus !== "authorized" && (
+        <div className="accessibility-banner">
+          <div style={{ marginBottom: 8 }}>
+            <strong>Microphone Permission {micStatus === "denied" ? "Denied" : "Required"}</strong>
+          </div>
+          <p style={{ margin: "0 0 10px", fontSize: 13, lineHeight: 1.5 }}>
+            {micStatus === "denied"
+              ? "Microphone access was denied. Please enable it in System Settings > Privacy & Security > Microphone."
+              : "Careless Whisper needs microphone access to record your voice for transcription."}
+          </p>
+          <button
+            className="btn-secondary"
+            onClick={() => {
+              if (micStatus === "denied") {
+                openUrl("x-apple.systempreferences:com.apple.preference.security?Privacy_Microphone");
+              } else {
+                invoke<string>("request_microphone").then((status) => {
+                  setMicStatus(status);
+                });
+              }
+            }}
+          >
+            {micStatus === "denied" ? "Open System Settings" : "Grant Microphone Access"}
           </button>
         </div>
       )}


### PR DESCRIPTION
## Summary
- **Fix repeated permission prompts**: Accessibility check now calls `AXIsProcessTrusted()` first without the prompt flag, only showing the system dialog if not already granted
- **Fix microphone permission detection**: Replaced broken AVFoundation FFI (symbol resolution issues with `AVMediaTypeAudio`) with reliable `swift` subprocess calls to check/request mic authorization
- **Fix push-to-talk mode**: Handle `ShortcutState::Released` to stop recording on key release (previously only `Pressed` was handled, so recording never stopped)
- **Add entitlements**: New `Entitlements.plist` with `audio-input` and `apple-events` capabilities for proper macOS permission caching
- **Add mic permission UI**: Settings banner shows microphone permission status with actionable button to grant access or open System Settings
- **Add debug logging**: Detailed permission state logging at startup (PID, executable path, accessibility/mic status)

## Test plan
- [ ] First launch: should prompt for accessibility + microphone once
- [ ] Grant both permissions, verify recording and auto-paste work
- [ ] Quit and relaunch: should NOT re-prompt for permissions
- [ ] Test push-to-talk mode: hold hotkey to record, release to stop and transcribe
- [ ] Test toggle mode: press to start, press again to stop
- [ ] Verify Settings UI shows correct permission status banners
- [ ] Verify mic "denied" state shows "Open System Settings" button

🤖 Generated with [Claude Code](https://claude.com/claude-code)