### PR TITLE
perf: tune whisper params for short-audio dictation latency

### DIFF
--- a/src-tauri/src/transcribe/whisper.rs
+++ b/src-tauri/src/transcribe/whisper.rs
@@ -30,7 +30,24 @@ pub fn transcribe(ctx: &WhisperContext, samples: &[f32], language: &str) -> Resu
     params.set_print_progress(false);
     params.set_print_realtime(false);
     params.set_print_timestamps(false);
-    params.set_single_segment(false);
+    params.set_token_timestamps(false);
+    params.set_no_context(true);
+
+    // Use all available CPU cores (capped at 16 to avoid diminishing returns)
+    let n_threads = std::thread::available_parallelism()
+        .map(|n| n.get().min(16) as i32)
+        .unwrap_or(4);
+    params.set_n_threads(n_threads);
+
+    // For short recordings (< 30s), single-segment mode avoids segmentation overhead
+    let duration_secs = samples.len() as f32 / 16000.0;
+    params.set_single_segment(duration_secs < 30.0);
+
+    let lang_label = if language == "auto" || language.is_empty() { "auto" } else { language };
+    log::info!(
+        "[whisper] transcribing {:.1}s audio | threads={} | language={} | single_segment={}",
+        duration_secs, n_threads, lang_label, duration_secs < 30.0
+    );
 
     // "auto" → empty string triggers whisper.cpp auto-detect
     if language != "auto" && !language.is_empty() {


### PR DESCRIPTION
Per your feedback on #20 — splitting the non-paste changes into their own PRs. This one carries the whisper tuning you said you wanted to discuss.

## What this changes (single file: `src-tauri/src/transcribe/whisper.rs`)

- `set_no_context(true)` — each dictation is independent; carrying prior-prompt context just adds decode work with no quality win for short clips
- `set_token_timestamps(false)` — we never render token timestamps; skip the work
- `set_n_threads(available_parallelism().min(16))` — default is too low on modern CPUs; cap at 16 to avoid diminishing returns on high-core boxes
- `set_single_segment(duration_secs < 30.0)` — short recordings skip segmentation overhead; long ones keep the old behavior
- A diagnostic `log::info!` line showing duration / threads / language / single-segment mode so the tuning is observable

## Discussion points you flagged
- `set_no_context(true)` does change output: prior-recording context no longer influences decoding. For dictation this is what you want (each press is a discrete utterance) but happy to make it opt-in if you'd rather
- Thread-count tuning is conservative (cap = 16) but if there's a project stance on CPU-use I'll adjust

Happy to split the no-context change out of this PR too if you'd prefer to land the perf knobs first and discuss the behavioral one separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)