### PR TITLE
feat: add Translate to English toggle

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -171,12 +171,13 @@ fn emit_transcription_error(app: &AppHandle, message: impl Into<String>) {
 
 fn transcription_inputs(
     state: &State<'_, AppState>,
-) -> (String, bool, Option<FocusTarget>, String, PathBuf) {
+) -> (String, bool, bool, Option<FocusTarget>, String, PathBuf) {
     let settings = state.settings.lock().unwrap().clone();
     let model_path = downloader::model_path(&settings.active_model);
     (
         settings.language,
         settings.auto_paste,
+        settings.translate_to_english,
         state.target_focus.lock().unwrap().clone(),
         settings.active_model,
         model_path,
@@ -188,14 +189,15 @@ fn spawn_transcription(
     samples_16k: Vec<f32>,
     language: String,
     auto_paste: bool,
+    translate_to_english: bool,
     target_focus: Option<FocusTarget>,
     active_model: String,
     model_path: PathBuf,
     hide_overlay_on_finish: bool,
 ) {
     log::info!(
-        "[transcribe] starting: model='{}', language='{}', samples={}, auto_paste={}, target={:?}",
-        active_model, language, samples_16k.len(), auto_paste, target_focus
+        "[transcribe] starting: model='{}', language='{}', translate={}, samples={}, auto_paste={}, target={:?}",
+        active_model, language, translate_to_english, samples_16k.len(), auto_paste, target_focus
     );
 
     tokio::task::spawn_blocking(move || {
@@ -225,7 +227,7 @@ fn spawn_transcription(
             },
         };
 
-        let result = crate::transcribe::whisper::transcribe(&ctx, &samples_16k, &language);
+        let result = crate::transcribe::whisper::transcribe(&ctx, &samples_16k, &language, translate_to_english);
         *state.whisper_ctx.lock().unwrap() = Some(ctx);
 
         match result {
@@ -354,7 +356,7 @@ pub async fn stop_recording(app: AppHandle, state: State<'_, AppState>) -> Resul
 
     let samples_16k =
         crate::audio::resample::resample_to_16k(raw_samples, sample_rate, channels as usize)?;
-    let (language, auto_paste, target_focus, active_model, model_path) =
+    let (language, auto_paste, translate_to_english, target_focus, active_model, model_path) =
         transcription_inputs(&state);
 
     spawn_transcription(
@@ -362,6 +364,7 @@ pub async fn stop_recording(app: AppHandle, state: State<'_, AppState>) -> Resul
         samples_16k,
         language,
         auto_paste,
+        translate_to_english,
         target_focus,
         active_model,
         model_path,
@@ -388,7 +391,7 @@ pub async fn transcribe_audio_file(
     let (samples, sample_rate, channels) = crate::audio::decode::decode_audio_file(&path)?;
     let samples_16k =
         crate::audio::resample::resample_to_16k(samples, sample_rate, channels as usize)?;
-    let (language, _auto_paste, _target_focus, active_model, model_path) =
+    let (language, _auto_paste, translate_to_english, _target_focus, active_model, model_path) =
         transcription_inputs(&state);
 
     spawn_transcription(
@@ -396,6 +399,7 @@ pub async fn transcribe_audio_file(
         samples_16k,
         language,
         false,
+        translate_to_english,
         None,
         active_model,
         model_path,

--- a/src-tauri/src/config/settings.rs
+++ b/src-tauri/src/config/settings.rs
@@ -29,6 +29,8 @@ pub struct Settings {
     pub overlay_position: OverlayPosition,
     #[serde(default = "default_true")]
     pub lower_volume_while_recording: bool,
+    #[serde(default)]
+    pub translate_to_english: bool,
 }
 
 fn default_true() -> bool {
@@ -47,6 +49,7 @@ impl Default for Settings {
             launch_at_login: false,
             overlay_position: OverlayPosition::TopCenter,
             lower_volume_while_recording: true,
+            translate_to_english: false,
         }
     }
 }

--- a/src-tauri/src/transcribe/whisper.rs
+++ b/src-tauri/src/transcribe/whisper.rs
@@ -23,7 +23,7 @@ pub fn load_model(path: &Path) -> Result<WhisperContext, String> {
     })
 }
 
-pub fn transcribe(ctx: &WhisperContext, samples: &[f32], language: &str) -> Result<String, String> {
+pub fn transcribe(ctx: &WhisperContext, samples: &[f32], language: &str, translate: bool) -> Result<String, String> {
     let mut state = ctx.create_state().map_err(|e| format!("{:?}", e))?;
 
     let mut params = FullParams::new(SamplingStrategy::Greedy { best_of: 1 });
@@ -31,6 +31,7 @@ pub fn transcribe(ctx: &WhisperContext, samples: &[f32], language: &str) -> Resu
     params.set_print_realtime(false);
     params.set_print_timestamps(false);
     params.set_single_segment(false);
+    params.set_translate(translate);
 
     // "auto" → empty string triggers whisper.cpp auto-detect
     if language != "auto" && !language.is_empty() {

--- a/src/components/Settings.tsx
+++ b/src/components/Settings.tsx
@@ -15,6 +15,7 @@ interface Settings {
   launch_at_login: boolean;
   overlay_position: "top_center" | "bottom_center" | "top_left" | "top_right";
   lower_volume_while_recording: boolean;
+  translate_to_english: boolean;
 }
 
 const AUDIO_FILE_FILTERS = [
@@ -324,6 +325,16 @@ export function Settings() {
             checked={settings.lower_volume_while_recording}
             onChange={(e) =>
               setSettings({ ...settings, lower_volume_while_recording: e.target.checked })
+            }
+          />
+        </div>
+        <div className="settings-toggle">
+          <span>Translate to English</span>
+          <input
+            type="checkbox"
+            checked={settings.translate_to_english}
+            onChange={(e) =>
+              setSettings({ ...settings, translate_to_english: e.target.checked })
             }
           />
         </div>


### PR DESCRIPTION
Per your feedback on #20 — splitting the translate feature out of the paste-fix PR.

## What this changes (4 files)

- `src-tauri/src/config/settings.rs` — new `translate_to_english: bool` field, defaults to `false` (via `#[serde(default)]` so existing configs stay valid)
- `src-tauri/src/transcribe/whisper.rs` — `transcribe()` gains a `translate: bool` param and calls `params.set_translate(translate)`
- `src-tauri/src/commands.rs` — wires the setting from `AppState` through `transcription_inputs` → `spawn_transcription` → `whisper::transcribe`, and includes `translate=...` in the transcribe-start log
- `src/components/Settings.tsx` — adds the "Translate to English" checkbox alongside the other toggles

## Why

Non-English speakers (my case: Hebrew) often want to dictate in their native language but paste English into the focused app — whisper.cpp supports this natively via the translate flag, this just exposes it. Off by default, no behavioral change for current users.

## Scope notes
- No whisper tuning in this PR — that's separate (#23)
- No paste fixes — that's #20

🤖 Generated with [Claude Code](https://claude.com/claude-code)