### PR TITLE
perf: tune whisper params for short-audio dictation latency

### DIFF
--- a/src-tauri/src/transcribe/whisper.rs
+++ b/src-tauri/src/transcribe/whisper.rs
@@ -30,8 +30,23 @@ pub fn transcribe(ctx: &WhisperContext, samples: &[f32], language: &str, transla
     params.set_print_progress(false);
     params.set_print_realtime(false);
     params.set_print_timestamps(false);
-    params.set_single_segment(false);
+    params.set_token_timestamps(false);
     params.set_translate(translate);
+
+    let n_threads = std::thread::available_parallelism()
+        .map(|n| n.get().min(16) as i32)
+        .unwrap_or(4);
+    params.set_n_threads(n_threads);
+
+    let duration_secs = samples.len() as f32 / 16000.0;
+    let single_segment = duration_secs < 30.0;
+    params.set_single_segment(single_segment);
+
+    let lang_label = if language == "auto" || language.is_empty() { "auto" } else { language };
+    log::info!(
+        "[whisper] transcribing {:.1}s audio | threads={} | language={} | single_segment={}",
+        duration_secs, n_threads, lang_label, single_segment
+    );
 
     // "auto" → empty string triggers whisper.cpp auto-detect
     if language != "auto" && !language.is_empty() {


### PR DESCRIPTION
Split of #23 per your review request — the pure-perf knobs only, independent of any behavioral change to transcription output.

## What's in this PR

- `set_token_timestamps(false)` — skip per-token timestamp generation (unused)
- `set_n_threads(available_parallelism, capped at 16)` — saturate cores, cap to avoid diminishing returns on high-core boxes
- `set_single_segment(duration < 30s)` — skip segmentation overhead for short clips; long audio still segments normally
- `[whisper]` diagnostic log line (duration, threads, language, single-segment mode) — useful for diagnosing regressions

## What's **not** in this PR

`set_no_context(true)` stays on #23. Your point about `create_state()` running per recording is well-taken — I want to go back and verify whether there's any within-recording behavior I've actually observed that would justify keeping it, before asking you to merge that one. If I can't produce a concrete case I'll close #23 on its own.