### PR TITLE
fix(windows): inject text via KEYEVENTF_UNICODE instead of Ctrl+V

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -257,7 +257,7 @@ fn spawn_transcription(
 
                 if clipboard_ok && auto_paste {
                     if let Some(target) = target_focus {
-                        match crate::output::paste::paste_into_target(target) {
+                        match crate::output::paste::paste_into_target(target, text) {
                             Ok(()) => {
                                 // Paste succeeded — restore the user's original clipboard
                                 if let Some(prev) = previous_clipboard {

--- a/src-tauri/src/output/paste.rs
+++ b/src-tauri/src/output/paste.rs
@@ -34,7 +34,7 @@ pub fn get_frontmost_target() -> Option<FocusTarget> {
 
 /// Activates the target app and simulates Cmd+V via CoreGraphics CGEventPostToPid.
 #[cfg(target_os = "macos")]
-pub fn paste_into_target(target: FocusTarget) -> Result<(), String> {
+pub fn paste_into_target(target: FocusTarget, _text: &str) -> Result<(), String> {
     use objc2::msg_send;
     use objc2::runtime::AnyClass;
     use std::os::raw::c_void;
@@ -110,9 +110,18 @@ pub fn get_frontmost_target() -> Option<FocusTarget> {
     }
 }
 
-/// Activates the target window and simulates Ctrl+V via SendInput.
+/// Activates the target window and injects the transcribed text.
+///
+/// Uses `KEYEVENTF_UNICODE` to inject each character as a unicode code point
+/// rather than synthesizing Ctrl+V. Ctrl+V via SendInput fails when the
+/// foreground thread's keyboard layout is non-Latin (e.g. Hebrew) because
+/// some apps don't accept Ctrl+V at all under those layouts — even a
+/// human pressing Ctrl+V on the physical keyboard does nothing in that
+/// state. Unicode injection bypasses all keyboard-shortcut handling and
+/// just delivers the characters as if they had been typed (or pasted by
+/// an IME), so it works regardless of the active layout.
 #[cfg(target_os = "windows")]
-pub fn paste_into_target(target: FocusTarget) -> Result<(), String> {
+pub fn paste_into_target(target: FocusTarget, text: &str) -> Result<(), String> {
     use std::mem;
     use windows::Win32::Foundation::HWND;
     use windows::Win32::System::Threading::{AttachThreadInput, GetCurrentThreadId};
@@ -175,42 +184,48 @@ pub fn paste_into_target(target: FocusTarget) -> Result<(), String> {
 
     std::thread::sleep(std::time::Duration::from_millis(150));
 
-    // Verify the target is actually foreground before sending Ctrl+V
+    // Verify the target is actually foreground before injecting input
     let actual_fg = unsafe { GetForegroundWindow() };
     if actual_fg != hwnd {
         log::warn!(
-            "[paste] target HWND {} is not foreground (actual={}), Ctrl+V may go to wrong window",
+            "[paste] target HWND {} is not foreground (actual={}), input may go to wrong window",
             target,
             actual_fg.0 as isize
         );
     }
 
-    // Send Ctrl+V
-    unsafe {
-        let mut inputs: [INPUT; 4] = mem::zeroed();
+    // Inject each character as a unicode code point. Each char becomes a
+    // (key-down, key-up) pair; surrogate pairs are sent as two events for
+    // the high and low surrogates (UTF-16 gives us this naturally).
+    // SendInput accepts the whole batch in one syscall regardless of length.
+    let utf16: Vec<u16> = text.encode_utf16().collect();
+    if utf16.is_empty() {
+        return Ok(());
+    }
 
-        // Ctrl down
-        inputs[0].r#type = INPUT_KEYBOARD;
-        inputs[0].Anonymous.ki.wVk = VK_CONTROL;
+    let mut inputs: Vec<INPUT> = Vec::with_capacity(utf16.len() * 2);
+    for &unit in &utf16 {
+        let mut down: INPUT = unsafe { mem::zeroed() };
+        down.r#type = INPUT_KEYBOARD;
+        down.Anonymous.ki.wScan = unit;
+        down.Anonymous.ki.dwFlags = KEYEVENTF_UNICODE;
 
-        // V down
-        inputs[1].r#type = INPUT_KEYBOARD;
-        inputs[1].Anonymous.ki.wVk = VK_V;
+        let mut up: INPUT = unsafe { mem::zeroed() };
+        up.r#type = INPUT_KEYBOARD;
+        up.Anonymous.ki.wScan = unit;
+        up.Anonymous.ki.dwFlags = KEYEVENTF_UNICODE | KEYEVENTF_KEYUP;
 
-        // V up
-        inputs[2].r#type = INPUT_KEYBOARD;
-        inputs[2].Anonymous.ki.wVk = VK_V;
-        inputs[2].Anonymous.ki.dwFlags = KEYEVENTF_KEYUP;
+        inputs.push(down);
+        inputs.push(up);
+    }
 
-        // Ctrl up
-        inputs[3].r#type = INPUT_KEYBOARD;
-        inputs[3].Anonymous.ki.wVk = VK_CONTROL;
-        inputs[3].Anonymous.ki.dwFlags = KEYEVENTF_KEYUP;
-
-        let sent = SendInput(&inputs, mem::size_of::<INPUT>() as i32);
-        if sent != 4 {
-            return Err(format!("SendInput sent {} of 4 events", sent));
-        }
+    let expected = inputs.len() as u32;
+    let sent = unsafe { SendInput(&inputs, mem::size_of::<INPUT>() as i32) };
+    if sent != expected {
+        return Err(format!(
+            "SendInput sent {} of {} events ({} UTF-16 code units)",
+            sent, expected, utf16.len()
+        ));
     }
 
     std::thread::sleep(std::time::Duration::from_millis(50));
@@ -261,7 +276,7 @@ pub fn get_frontmost_target() -> Option<FocusTarget> {
 /// - If we only have the "wayland" marker, uses the Wayland paste fallback
 ///   chain (ydotool → wtype → xdotool).
 #[cfg(target_os = "linux")]
-pub fn paste_into_target(target: FocusTarget) -> Result<(), String> {
+pub fn paste_into_target(target: FocusTarget, _text: &str) -> Result<(), String> {
     if target == "wayland" {
         return paste_wayland();
     }


### PR DESCRIPTION
## What

Replace the Windows paste path (Ctrl+V via `SendInput`) with direct unicode character injection using `KEYEVENTF_UNICODE`.

## Why

Ctrl+V via `SendInput` — with virtual keys (`VK_CONTROL` + `VK_V`) — fails silently when the foreground window's keyboard layout is non-Latin (e.g. Hebrew, Arabic, CJK). Some apps filter the Ctrl+V shortcut through the active layout's character map, so the VK_V keydown is never processed as a paste accelerator. This isn't a bug in the simulation: the same physical Ctrl+V keypress on the hardware keyboard does nothing in those apps under those layouts either.

There is no scan-code or `wVk` override that reliably fixes this, because the receiving app's shortcut dispatch uses the VK *as translated by the foreground layout*, not the raw scan code.

## Change

- `paste_into_target` on Windows now accepts the transcribed `text: &str` and injects it character-by-character using `KEYEVENTF_UNICODE` + `KEYEVENTF_KEYUP` pairs via a single `SendInput` batch call.
- The function signature gains a `text: &str` parameter on all platforms (macOS and Linux accept `_text` and continue using their existing Cmd+V / xdotool approaches).
- The clipboard write is unchanged, so the user can still manually Ctrl+V the transcription.

## Verification

Tested on Windows 11 with keyboard layout switched to Hebrew:

1. Switch keyboard layout to Hebrew (`Win + Space`)
2. Open Notepad (or any text editor)
3. Press the recording hotkey → speak English → release
4. With the old code: nothing was pasted. With this fix: transcribed English text appears in the editor.
5. Checked that switching back to English layout still works as before.