### PR TITLE
feat: add realtime transcription mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,9 +5,22 @@
 
 # Careless Whisper
 
-A lightweight, always-on desktop app for local voice-to-text transcription. Lives in the system tray / menu bar, records on a global hotkey, transcribes locally with Whisper, and pastes the result into your focused app. No cloud. No data leaves your machine.
+Careless Whisper is a lightweight, always-on desktop app for local voice-to-text transcription. It lives in the system tray / menu bar, records from a global hotkey, transcribes locally with Whisper, and keeps your audio on your machine.
+
+The original stop-to-transcribe workflow is still here: press the hotkey, speak, press it again, and the final transcript is pasted into your focused app. Optional realtime mode shows partial transcription text in the overlay while you are still recording.
+
+No cloud. No accounts. No data leaves your machine.
 
 Supports **macOS** and **Windows**.
+
+## Realtime Dictation
+
+- **Realtime transcription mode** - optional partial transcript updates while recording.
+- **Live overlay text** - the recording overlay can show the growing transcript instead of only a timer.
+- **Classic mode preserved** - final transcription and paste still use the reliable batch path.
+- **Local-first experiments** - realtime POC notes, tuning docs, and test scripts are kept in `docs/` and `poc/`.
+
+Realtime mode is experimental. It currently works by transcribing short chunks while capture continues, so it is closer to near-realtime dictation than character-by-character streaming. Batch mode remains the dependable fallback.
 
 **Website:** [yarivgilad.github.io/careless-whisper](https://yarivgilad.github.io/careless-whisper/)
 
@@ -53,7 +66,7 @@ After that, the app will open normally.
 
 ### Windows
 
-1. Download the installer from the [Releases](https://github.com/yarivgilad/careless-whisper/releases) page.
+1. Download the installer from the [Releases](https://github.com/YarivGilad/careless-whisper/releases) page.
 2. Run the installer and follow the prompts.
 
 > The app lives in the **system tray** (bottom-right of your screen).
@@ -67,14 +80,39 @@ The Settings window will open automatically because no model is downloaded yet.
 3. Your OS will ask for **Microphone** access the first time you record — allow it.
 4. **macOS only:** Go to **System Settings → Privacy & Security → Accessibility** and enable Careless Whisper so it can paste text into other apps.
 
-### Record and transcribe
+### Classic dictation
 
 1. Click into any text field in any app (your target).
 2. Press the hotkey (default: **Cmd+Shift+Space** on macOS, **Ctrl+Shift+Space** on Windows) — a small recording indicator appears.
 3. Speak.
 4. Press the hotkey again to stop — the transcribed text is pasted directly where your cursor was.
 
-The hotkey, language, and other options can be changed from **Settings** in the tray menu.
+Click the menu-bar icon to open **Settings**. Secondary-click the icon to open
+the app menu with language and quit actions. Settings save automatically as you
+change them.
+
+The Settings **Start Recording** button hides Settings briefly before recording
+starts. Focus the destination text field when Settings closes so the app can
+capture the target cursor. The global hotkey is still the fastest and most
+reliable way to start from an already-focused text field.
+
+### Realtime transcription
+
+Enable **Realtime transcription** in Settings to show partial transcript text in
+the overlay while recording. The recording bubble also shows the current mode
+and lets you arm or disable realtime mode while a recording is active. The
+bubble can be dragged if it appears in an awkward spot.
+
+When **Auto-paste after transcription** is also enabled, realtime chunks are
+typed into the focused app during recording through the captured hotkey target.
+When you stop, realtime mode skips the old full batch transcription path because
+the text was already produced during recording. Very short realtime recordings
+that stop before any chunk returns fall back to the classic final pass.
+
+Platform note: realtime capture and Whisper chunking are cross-platform Rust
+paths, but the direct live-typing path is currently macOS-specific. Windows and
+Linux keep the clipboard-plus-paste fallback for realtime chunks and need
+dedicated QA before claiming parity, especially on Linux Wayland sessions.
 
 ## Default Hotkey
 
@@ -104,6 +142,27 @@ On first launch the app will prompt you to download a model. Models are stored l
 - No special permissions needed.
 
 ---
+
+## Development Docs
+
+Realtime dictation work is tracked separately so the POC, plan, and open
+questions stay discoverable.
+
+| Path | Purpose |
+|---|---|
+| `docs/realtime_whisper_discussion.md` | Original realtime dictation architecture discussion and feasibility notes. |
+| `docs/realtime_whisper/plan.md` | Phase plan for realtime dictation, from standalone POC through app integration. |
+| `docs/realtime_whisper/implementation_tracker.md` | POC status, completed realtime experiments, and next test commands. |
+| `docs/realtime_whisper/current_issues.md` | Active risks, resolved findings, and tuning questions. |
+| `poc/README.md` | POC runbook and file map. Start here for local realtime experiments. |
+| `poc/realtime_mic_poc.py` | Continuous/chunked ffmpeg capture runner that invokes local `whisper.cpp`. |
+| `poc/run_whisper_stream.sh` | Wrapper for the `whisper-stream` comparison path. |
+| `poc/test_samples.md` | Fixed English and Hebrew read-aloud samples for repeatable comparisons. |
+| `docs/security/audit-2026-03-22.md` | Security audit notes. |
+| `docs/index.html` and `docs/assets/` | Static project website assets. |
+
+Generated POC artifacts live under `poc/audio/`, `poc/models/`, and
+`poc/vendor/`; they are documented in `poc/README.md` and ignored by git.
 
 ## Building from Source
 

--- a/docs/realtime_whisper/current_issues.md
+++ b/docs/realtime_whisper/current_issues.md
@@ -1,0 +1,199 @@
+# Realtime Whisper Current Issues
+
+This file tracks open questions and known problems for the realtime dictation
+effort. Keep it short and current.
+
+## Open Issues
+
+### App Prototype Needs Live Validation
+
+The Rust/Tauri realtime prototype is wired in, but it still needs more real app
+testing with microphone permission, the overlay window, captured target focus,
+live chunk paste, and stop behavior together.
+
+Next action: run the app, enable **Realtime transcription** and **Auto-paste
+after transcription**, start from a focused text field with the global hotkey,
+record the English control paragraph from `poc/test_samples.md`, and compare
+overlay partials, live pasted chunks, and whether stop exits cleanly without a
+second batch transcription pass after at least one live chunk appears.
+
+### Continuous Runner Latency Is Still Noticeable
+
+With the correct microphone device (`:1`), continuous capture is good enough to
+prove audio/model quality but still feels slow for realtime dictation. The first
+continuous English control result was broadly correct, but text still appears
+after chunk boundaries rather than truly live.
+
+Mitigation already added: `realtime_mic_poc.py` now defaults to continuous
+ffmpeg capture, so recording continues while Whisper transcribes previous
+chunks. This reduces dropped words from capture gaps, but it still launches
+`whisper-cli` and loads the model for every chunk.
+
+Next action: test the English sample with continuous capture:
+
+```sh
+python3 poc/realtime_mic_poc.py --gpu --chunk-seconds 5 --max-chunks 8 --keep-audio
+```
+
+Then compare a persistent-model path:
+
+```sh
+poc/run_whisper_stream.sh
+```
+
+If the default SDL capture is wrong, inspect the capture device list printed at
+startup and only then try `poc/run_whisper_stream.sh --capture N`.
+
+### Stream Mode Quality Is Poor So Far
+
+The first stream test with `--capture 1` hallucinated text, which suggests SDL
+capture ID `1` is not the same as ffmpeg's AVFoundation `:1`. Running without
+`--capture` produced Hebrew output, but it was garbled and repeated phrases like
+`תודה רבה`. Timings ended around 57 seconds with many fallbacks, so this is not
+yet a usable realtime path.
+
+Next action: use the English sample in `poc/test_samples.md` first as the
+control case, then compare Hebrew once the pipeline behavior is understood.
+
+### English Quality Has Minor Chunk Artifacts
+
+The first continuous English result was readable and mostly accurate, but still
+included minor artifacts: duplicated "I'm", "testing" misheard as "just in",
+and small missing/substituted words. These look like chunk-boundary/context
+issues rather than broken capture.
+
+Next action: after latency, test chunk duration and overlap/deduplication.
+
+### Hebrew Quality Is Mixed With Base Model
+
+The first valid mic run produced one good Hebrew chunk:
+`אפשר להמשיך לעבוד בצורה כזאתי`, but earlier chunks were garbled. This may be
+from short chunks, lack of context/VAD, the base model, or normal Whisper
+instability on small audio windows.
+
+Next action: defer Hebrew tuning until English chunked and stream baselines are
+understood.
+
+## Resolved / Explained
+
+### Mic Capture Was All-Zero Audio
+
+The second live command:
+
+```sh
+python3 poc/realtime_mic_poc.py --device ':0' --language he --gpu --max-chunks 3 --keep-audio
+```
+
+produced chunks with `rms=-inf` and `peak=-inf`. Inspecting the saved WAV files
+confirmed every sample was zero. This is digital silence, not low-quality
+Hebrew transcription.
+
+Confirmed cause:
+
+- `--device ':0'` mapped to `Virtual Desktop Speakers`, not the MacBook mic.
+- `--device ':1'` maps to `MacBook Pro Microphone`.
+
+Resolution: use `--device ':1'`, now also the POC default on this machine.
+
+### First Hebrew GPU Run Hallucinated Repeated Text
+
+The first live command:
+
+```sh
+python3 poc/realtime_mic_poc.py --device ':0' --language he --gpu
+```
+
+returned repeated `הוא עוד קצת את זה` phrases for multiple chunks. That does
+not look like usable Hebrew dictation. Later device listing showed `:0` was
+`Virtual Desktop Speakers`, so this was Whisper hallucinating on all-zero audio.
+
+Resolution: re-run with `--device ':1'`; the hallucinated phrase was from
+recording all-zero audio on `:0`.
+
+### Mic Access In Codex Sandbox
+
+`ffmpeg` did not list AVFoundation audio devices from the Codex sandbox. This
+does not mean the POC is broken; it means live mic validation needs to run from
+normal Terminal/iTerm with macOS microphone permission.
+
+Next action: run `python3 poc/realtime_mic_poc.py --list-devices` outside Codex.
+
+### Metal/GPU Path Needs A Real Terminal Test
+
+The `whisper.cpp` build detected Metal support, but the first reliable smoke
+test used CPU with `-ng`. GPU behavior should be tested from a normal terminal
+before assuming realtime latency numbers.
+
+Next action: compare `--gpu` vs default CPU on the same spoken phrase.
+
+### Sequential Chunked Capture Was Creating Gaps
+
+The first POC recorded one complete chunk, transcribed it, printed text, then
+recorded the next chunk. That proved local chunked transcription, but it left
+gaps while Whisper was running.
+
+Resolution: `realtime_mic_poc.py` now defaults to continuous ffmpeg capture, and
+the Rust prototype reads from the active app capture buffer while recording. The
+remaining issue is latency, not dropped audio during transcription.
+
+### Tauri Dev Linker Failure With Optimized Incremental Builds
+
+`pnpm tauri dev` was failing at link time on macOS arm64 with undefined
+`_anon...llvm...` serde symbols, while normal `cargo check` still passed. The
+failing command was reproduced as:
+
+```sh
+cargo build --manifest-path src-tauri/Cargo.toml --no-default-features --features metal
+```
+
+Resolution: the same command linked cleanly with `CARGO_INCREMENTAL=0`, so
+`src-tauri/Cargo.toml` now sets `incremental = false` for the optimized dev
+profile.
+
+### Duplicate Text Handling Is Unimplemented
+
+Overlapping windows are not active yet, so there is no duplicate-suffix or
+stable-prefix logic. This will matter as soon as we add overlap.
+
+Next action: add overlap only after baseline chunk latency is measured.
+
+### Realtime Commit Semantics Are Still Naive
+
+The app now pastes realtime chunks into the captured hotkey target when
+**Auto-paste after transcription** is enabled. On macOS this now uses Unicode
+keyboard events instead of clipboard-plus-Cmd+V when a target was captured. This
+validates the product path, but it commits whole chunk output directly. There is no overlap,
+duplicate-suffix handling, stable-prefix logic, or edit/replace strategy yet.
+
+Next action: test naive chunk commits first. If words repeat or chunk boundaries
+feel rough, add overlap plus deduplication before trying any arbitrary-app
+replace behavior.
+
+### Settings Start Has No External Text Target
+
+The Settings **Start Recording** button used to clear `target_focus`, so it
+could not type into the app where the user previously had a cursor. Clicking
+Settings changes the focused app to Settings itself, so immediate target capture
+from that button is not useful.
+
+Resolution: the button now hides Settings, waits briefly, captures the newly
+focused frontmost app, and then starts recording. The hotkey remains the most
+reliable start path.
+
+### VAD Is Deferred
+
+No voice activity detection is included in the POC. Without VAD, Whisper may
+process silence and produce unstable or empty chunks.
+
+Next action: evaluate whether chunked output is usable enough before adding VAD.
+
+### App Integration Must Preserve Batch Mode
+
+The current batch path is simple and reliable. Realtime work landed as an
+opt-in settings flag and overlay-only partial text, not as a replacement for the
+existing stop-then-transcribe behavior.
+
+Resolution: batch mode remains the default fallback. In realtime mode,
+auto-paste inserts live chunks during recording. Stop skips the final batch
+transcription pass after realtime has produced user-visible output; very short
+recordings fall back to the final pass if no live chunk returned.

--- a/docs/realtime_whisper/implementation_tracker.md
+++ b/docs/realtime_whisper/implementation_tracker.md
@@ -1,0 +1,186 @@
+# Realtime Whisper Implementation Tracker
+
+Source discussion: `docs/realtime_whisper_discussion.md`
+
+POC entry point: `poc/realtime_mic_poc.py`
+
+## Status
+
+| Phase | Status | Current State | Next Move |
+| --- | --- | --- | --- |
+| Phase 1 - Standalone POC | Complete enough | Mic capture works with `--device ':1'`; continuous capture produces usable English transcription; the runner prints timing/audio levels and a final transcript. | Keep using it as the baseline while testing latency improvements. |
+| Phase 2 - POC hardening | Started | Continuous capture fixed the capture-gap word-loss issue; remaining problems are latency and minor duplicate/substituted words. | Continue latency tuning in parallel with app validation. |
+| Phase 3 - App prototype | Implemented, needs live validation | The Tauri app has an opt-in realtime worker, partial transcript events, overlay display, live chunk paste behind Auto-paste, and clean realtime shutdown on stop without the old final batch pass once live text has been produced. | Run the app, enable Realtime transcription, and compare overlay partials, live pasted chunks, and stop behavior. |
+| Phase 4 - Stabilized output | Started | Realtime paste commits whole chunk text without overlap/deduplication or stable-prefix logic. | Test whether naive chunk commits are acceptable before adding overlap and dedupe. |
+| Phase 5 - Productization | Started lightly | Settings has a realtime arm/disable control and the recording bubble exposes the current mode, but defaults, tuning, and edge-case UX are not productized. | Defer deeper product work until the live prototype proves useful. |
+
+## Completed Work
+
+- Created `poc/` as an isolated realtime dictation experiment.
+- Cloned `ggerganov/whisper.cpp` into `poc/vendor/whisper.cpp`.
+- Built `whisper-cli` locally with Accelerate/Metal support detected by CMake.
+- Reused the installed app's verified base model via `poc/models/ggml-base.bin`.
+- Added `poc/realtime_mic_poc.py`.
+- Added `poc/README.md` with run instructions.
+- Verified `whisper-cli` can transcribe a generated speech WAV with the local
+  model on CPU.
+- Captured first live `--gpu --language he` result: 3-second chunks took about
+  6.8-9.3 seconds total and repeatedly emitted `הוא עוד קצת את זה`, which looks
+  like hallucination on silence, weak audio, wrong mic, or forced-language
+  noise rather than useful Hebrew dictation.
+- Updated the POC to print chunk RMS/peak levels and skip very quiet chunks by
+  default.
+- Captured second live `--gpu --language he --max-chunks 3 --keep-audio` result:
+  all chunks had `rms=-inf`, `peak=-inf`, and the saved WAV files contained zero
+  nonzero samples. This confirms ffmpeg is currently recording digital silence,
+  so microphone permission or device selection must be fixed before judging
+  Whisper quality.
+- Listed AVFoundation devices from normal Terminal. Audio `:0` is `Virtual
+  Desktop Speakers`, audio `:1` is `MacBook Pro Microphone`, and audio `:2` is
+  `Virtual Desktop Mic`. The next live mic test should use `--device ':1'`.
+- Captured first successful live mic result with `--device ':1' --language he
+  --gpu --max-chunks 3 --keep-audio`: speech levels were healthy
+  (`rms=-29.3` to `-33.3dBFS`, `peak=-12.2` to `-18.6dBFS`), Hebrew output was
+  mixed but real, and total time was 4.4-5.8 seconds per roughly 2.5-2.7 seconds
+  of captured audio.
+- Updated the POC default device to `:1` and added separate `record=` and
+  `whisper=` timing in chunk output.
+- Reconfigured `whisper.cpp` with `-DWHISPER_SDL2=ON` and built
+  `whisper-stream`.
+- Added `poc/run_whisper_stream.sh` as the next lower-latency test command.
+- Tested `whisper-stream`: `--capture 1` hallucinated text, while the default
+  SDL capture transcribed Hebrew but quality was poor and timings ended around
+  57 seconds with many fallbacks. Treat SDL capture ID `1` as suspect.
+- Added `poc/test_samples.md` with fixed Hebrew and English paragraphs for
+  repeatable quality comparisons.
+- Switched POC defaults to English-first: `realtime_mic_poc.py` now defaults to
+  `--language en`, and `poc/run_whisper_stream.sh` defaults to `-l en`.
+- Captured first English chunked run: transcription quality was usable, but the
+  transcript text was visually buried after timing metadata. Also observed that
+  ffmpeg recording took 6.1-7.9 seconds to produce about 4.3 seconds of audio,
+  while Whisper itself took about 1.1-2.0 seconds.
+- Updated `realtime_mic_poc.py` to print clear `TEXT [NNNN]:` lines and a final
+  `FULL TRANSCRIPT` block.
+- Identified likely cause of dropped words when speaking faster: the old
+  sequential runner stopped recording while each chunk was sent to Whisper.
+  Words spoken during `whisper=...` time were never captured.
+- Added `--capture-mode continuous` as the default. It keeps a single ffmpeg
+  process recording in a background reader and queues chunks while Whisper
+  transcribes earlier audio. The old behavior remains available with
+  `--capture-mode chunked`.
+- Captured first continuous English control result. Output was broadly correct:
+  "hello, this is a short test..." through "...next stage of the experiment."
+  Remaining errors were minor duplicate/substituted words such as duplicated
+  "I'm" and "testing" misheard as "just in". This proves the local capture plus
+  Whisper path is viable for English, but it still feels slow.
+- Installed the Rust toolchain locally and verified the Tauri native build can
+  compile on this machine.
+- Added `realtime_transcription` to persisted settings with a default of
+  `false`, plus a Settings checkbox labeled "Realtime transcription".
+- Added an opt-in Rust realtime transcription worker that reads from the active
+  capture buffer while recording, transcribes 4-second chunks through the
+  existing local Whisper model, and emits `realtime-transcription` events.
+- Added a shared transcription lock so concurrent Whisper work cannot reuse the
+  same context unsafely.
+- Updated the overlay to show accumulated partial text while recording.
+- Increased the overlay window height to fit the partial text prototype.
+- Verified `cargo check --manifest-path src-tauri/Cargo.toml` passes after the
+  Rust integration.
+- Verified `/usr/local/bin/corepack pnpm build` passes.
+- Verified `/opt/homebrew/bin/cargo test --manifest-path src-tauri/Cargo.toml`
+  passes with 35 Rust unit tests.
+- Pinned `packageManager` and changed Tauri dev/build hooks to `corepack pnpm`
+  so this repo does not require a separate global `pnpm` shim.
+- Added a menu-bar icon left-click handler that opens Settings. Secondary-click
+  still exposes the tray menu.
+- Updated the recording overlay so realtime mode is visible immediately: it now
+  shows a `Realtime` badge and a pending live-transcription line before the
+  first partial chunk returns.
+- Added a Settings Start/Stop Recording button. Manual Settings starts clear the
+  captured paste target, so they are safe for testing the overlay but do not
+  live-paste into a stale app target.
+- Added live chunk paste for realtime mode. It is gated by **Auto-paste after
+  transcription** and uses the captured hotkey target; realtime stop now skips
+  the old final batch transcription pass to avoid duplicate work and duplicate
+  output once at least one live chunk has been produced. Very short recordings
+  still fall back to the final batch path if no realtime output arrived before
+  stop.
+- Switched macOS target output from clipboard-plus-Cmd+V to Unicode keyboard
+  events for the captured target PID. Clipboard is now a fallback when no target
+  was captured or typing fails.
+- Added realtime arm/disable controls in the Settings recording section and in
+  the recording bubble. Toggling realtime while recording starts or stops the
+  realtime worker for the active session.
+- Added a `Typing` / `No target` / `Paste off` badge to the recording bubble so
+  both hotkey and button starts expose whether cursor insertion can happen.
+- Changed the Settings Start button to hide Settings, wait briefly, capture the
+  newly focused target, and then start recording. This gives the mouse path a
+  real way to type into another app.
+- Removed the Settings save button. Settings now autosave optimistically as each
+  control changes, with debouncing for typed fields like the hotkey and max
+  recording duration.
+- Made the recording bubble draggable, visible on all workspaces, and more
+  assertive on macOS fullscreen Spaces through native window collection behavior.
+- Changed the live transcript area from a single-line ellipsis to wrapped text
+  that grows the overlay window downward until a capped height, then keeps the
+  newest text visible.
+- Fixed overlay positioning on external monitors by positioning in physical
+  monitor coordinates with the target monitor's scale factor instead of doubling
+  external-monitor origins by the primary display scale.
+- Fixed Unicode log preview truncation so Hebrew final transcripts cannot panic
+  by slicing inside a multibyte character.
+- Disabled incremental compilation for the optimized Rust dev profile after the
+  exact Tauri dev command (`--no-default-features --features metal`) reproduced
+  intermittent macOS arm64 linker failures that disappeared with
+  `CARGO_INCREMENTAL=0`.
+
+## Next Test
+
+Run from normal Terminal/iTerm:
+
+```sh
+/usr/local/bin/corepack pnpm tauri dev
+```
+
+In the app Settings window, set Language to English or Auto, enable
+**Realtime transcription** and **Auto-paste after transcription**, then click
+into a text field and start recording with the global hotkey. Read the English
+control paragraph from `poc/test_samples.md`. Watch whether partial text appears
+in the overlay, whether chunks are inserted into the target app during
+recording, and whether stopping avoids a duplicate final paste. If recording is
+started from the Settings button, Settings hides briefly; focus the destination
+field before capture begins so the app has a target. The current local config was
+last observed as `language='he'`, so do not skip the language setting when
+testing English.
+
+POC comparison commands:
+
+```sh
+python3 poc/realtime_mic_poc.py --list-devices
+python3 poc/realtime_mic_poc.py --gpu --chunk-seconds 5 --max-chunks 8 --keep-audio
+python3 poc/realtime_mic_poc.py --capture-mode chunked --gpu --chunk-seconds 5 --max-chunks 8 --keep-audio
+poc/run_whisper_stream.sh
+python3 poc/realtime_mic_poc.py --language he --gpu --chunk-seconds 5 --max-chunks 8 --keep-audio
+poc/run_whisper_stream.sh -l he
+```
+
+If device `:0` is not the right microphone, use the audio device index reported
+by `--list-devices`.
+
+Healthy speech should show RMS clearly above the default `-50dBFS` silence
+threshold and `nonzero` above zero. If it does not, fix macOS microphone
+permission, device selection, or input gain before tuning Whisper.
+
+## Notes To Preserve
+
+- The installed app already downloaded `ggml-base.bin` and config currently
+  uses `active_model: "base"` and `language: "he"`.
+- The Codex sandbox did not expose AVFoundation microphone devices, so live mic
+  validation must happen outside this sandbox.
+- The POC defaults to CPU by passing `-ng`; use `--gpu` to compare Metal.
+- Continuous capture is the current best baseline. It reduces dropped words from
+  capture gaps, but it still launches `whisper-cli` per chunk, so a persistent
+  model path remains the next optimization.
+- SDL capture IDs do not match ffmpeg/AVFoundation IDs reliably. Prefer the
+  default SDL capture first; only pass `--capture N` after checking the device
+  list printed by `whisper-stream`.

--- a/docs/realtime_whisper/plan.md
+++ b/docs/realtime_whisper/plan.md
@@ -1,0 +1,101 @@
+# Realtime Whisper Plan
+
+This plan tracks the realtime dictation effort described in
+`docs/realtime_whisper_discussion.md`. The first phase is intentionally a
+standalone POC before integrating anything into the Tauri app.
+
+## Phase 1 - Standalone POC
+
+Goal: prove that local chunked microphone transcription is practical on this
+machine.
+
+Scope:
+
+- Keep the experiment outside the app under `poc/`.
+- Use the already-downloaded `ggml-base.bin` model from Careless Whisper app
+  data.
+- Record short microphone chunks.
+- Send each chunk to local `whisper.cpp`.
+- Print recognized text to the terminal.
+- Measure rough latency and transcription quality for English and Hebrew.
+
+Done when:
+
+- The POC can list usable microphone devices from a normal Terminal session.
+- Speaking into the mic produces chunk-level text output.
+- We know whether CPU is enough or Metal/GPU is required.
+- We have notes on chunk duration, language quality, and observed latency.
+
+## Phase 2 - POC Hardening
+
+Goal: make the experiment representative enough to guide app design.
+
+Scope:
+
+- Try chunk sizes around 1, 2, and 3 seconds.
+- Compare CPU vs Metal/GPU.
+- Add optional overlap between chunks.
+- Add simple duplicate-suffix filtering.
+- Keep unstable text in terminal output only.
+- Capture failure modes from microphone permissions and device selection.
+
+Done when:
+
+- We can describe the expected latency/quality tradeoff.
+- We have a preferred chunk size and overlap strategy.
+- We know whether basic deduplication is sufficient for a first app prototype.
+
+## Phase 3 - App Prototype: Internal Partial Text
+
+Goal: integrate the streaming path into Careless Whisper without typing into
+other apps yet.
+
+Scope:
+
+- Add a streaming capture path alongside existing batch transcription.
+- Send audio chunks to a background transcription worker.
+- Emit partial transcript events to the overlay or logs.
+- Preserve the existing batch mode as the reliable default.
+- Avoid clipboard and paste changes in this phase.
+
+Done when:
+
+- Starting recording creates live partial transcript events.
+- Stopping recording shuts down the worker cleanly.
+- Batch transcription still works unchanged.
+
+## Phase 4 - Stabilized Dictation Output
+
+Goal: send only stable committed text to the target app.
+
+Scope:
+
+- Split transcript state into partial and committed text.
+- Add VAD or silence-based commit boundaries.
+- Deduplicate overlapping chunk text.
+- Decide whether commits use clipboard paste, simulated typing, or a hybrid.
+- Preserve or restore clipboard where possible.
+
+Done when:
+
+- Dictated text appears in the original focused app without obvious duplicates.
+- Partial revisions do not corrupt text already committed to the target app.
+- Focus changes and paste failures have defined behavior.
+
+## Phase 5 - Productization
+
+Goal: make realtime dictation a user-facing mode.
+
+Scope:
+
+- Add settings for realtime vs batch mode.
+- Tune defaults by model size and platform.
+- Add cancellation, errors, and performance reporting.
+- Test on macOS first, then Windows.
+- Keep batch mode available as the dependable fallback.
+
+Done when:
+
+- Realtime dictation is usable for normal writing.
+- Performance and edge cases are documented.
+- The implementation can be reviewed as a bounded app feature.

--- a/docs/realtime_whisper_discussion.md
+++ b/docs/realtime_whisper_discussion.md
@@ -1,0 +1,225 @@
+# Realtime Whisper Dictation Discussion
+
+## Current Transcription Flow
+
+Careless Whisper currently uses a batch transcription model:
+
+1. The user presses the global hotkey.
+2. The app captures microphone audio into memory.
+3. The user presses the hotkey again, or releases it in push-to-talk mode.
+4. Capture stops.
+5. The full audio buffer is resampled to mono 16 kHz.
+6. Whisper transcribes the complete buffer once.
+7. The final text is copied to the clipboard and optionally pasted into the app that was focused before recording started.
+
+The live microphone path is hotkey-driven, not a visible React record button.
+
+Relevant code:
+
+- `src-tauri/src/hotkey/manager.rs`: registers the global hotkey and emits `hotkey-start` / `hotkey-stop`.
+- `src/App.tsx`: the overlay window listens for those events and invokes `start_recording` / `stop_recording`.
+- `src-tauri/src/commands.rs`: owns the command flow, recording lifecycle, transcription worker, clipboard copy, and paste.
+- `src-tauri/src/audio/capture.rs`: uses `cpal` to capture audio from the default input device.
+- `src-tauri/src/audio/resample.rs`: converts captured audio to mono 16 kHz.
+- `src-tauri/src/transcribe/whisper.rs`: wraps `whisper-rs` and runs Whisper over a complete audio buffer.
+
+There is also a settings UI button for transcribing existing audio files, but that is separate from live microphone capture.
+
+## Desired Realtime Behavior
+
+The desired behavior is closer to browser dictation:
+
+1. The microphone buffer streams in continuously.
+2. Audio chunks are sent to Whisper while recording is still active.
+3. Text comes out incrementally.
+4. The text is sent into the currently focused app, so the user can speak anywhere they would normally type.
+
+This is similar in user experience to browser speech recognition, commonly exposed through the Web Speech API as `SpeechRecognition` / `webkitSpeechRecognition`, but system-wide instead of limited to a browser input or web component.
+
+The advantage of doing this locally with Whisper is that dictation could work across the whole desktop and without cloud transcription.
+
+## Is This Possible Here?
+
+Yes. The repo already has several important pieces:
+
+- Microphone capture through `cpal`.
+- Local Whisper inference through `whisper-rs`.
+- Settings, language selection, model management, and model reuse.
+- Focus capture before recording starts.
+- Clipboard and paste integration for sending text into another app.
+- Overlay UI for recording/transcribing state.
+
+The missing piece is a streaming dictation pipeline between microphone capture and text output.
+
+This would not be a small flag on the current implementation. The current code is structured around:
+
+```text
+record full audio -> stop -> resample -> transcribe once -> paste final text
+```
+
+Realtime dictation would need something more like:
+
+```text
+capture chunks -> run continuous worker -> transcribe overlapping windows -> stabilize text -> commit text to target app
+```
+
+## Main Architecture Change
+
+The microphone capture layer currently appends samples to a `Vec<f32>` and returns that complete buffer when recording stops.
+
+Realtime dictation would likely replace or extend this with a channel or ring buffer:
+
+1. `cpal` callback receives audio frames.
+2. Frames are pushed into a thread-safe stream buffer.
+3. A transcription worker consumes chunks while recording continues.
+4. Chunks are converted to mono 16 kHz.
+5. Whisper runs on rolling windows of recent audio.
+6. New stable text is emitted to the output path.
+
+The batch mode can still remain as the default or fallback path.
+
+## Difficulties
+
+### Whisper Is Not Naturally Browser-Style Realtime
+
+The current Whisper call uses `state.full(params, samples)`, which expects an audio window and returns segments for that window. It is not the same kind of streaming API as browser speech recognition.
+
+Whisper can be used for near-realtime transcription by repeatedly running it on short audio windows, but it may revise earlier words when it receives more context.
+
+### Latency vs Accuracy
+
+Small chunks produce faster feedback but worse stability.
+
+Larger chunks improve accuracy but feel less realtime.
+
+A practical first target would probably use 1-3 second chunks with overlap, not character-by-character transcription.
+
+### Duplicate Text Handling
+
+Sliding windows will repeat content. For example, a 3-second window with 1 second of overlap may transcribe words that were already emitted.
+
+The app would need logic to compare the new transcript against previously committed text and emit only the stable new suffix.
+
+### Partial vs Committed Text
+
+In a browser text area, an app can show partial text and then replace it when recognition revises the phrase.
+
+System-wide dictation is harder. Once text is pasted or typed into another app, changing it requires backspaces, selections, or replacement commands. That gets brittle across arbitrary desktop apps.
+
+A safer approach is:
+
+- Keep unstable partial text internal or in the overlay.
+- Only send text to the target app once it is stable enough.
+- Optionally commit on silence boundaries detected by VAD.
+
+### Voice Activity Detection
+
+Realtime dictation benefits from VAD or silence detection. Without it, Whisper may run too often, waste compute, and emit unstable text.
+
+VAD could help decide:
+
+- When speech starts.
+- When a phrase is complete.
+- When to commit text to the focused app.
+- When to ignore silence.
+
+### CPU/GPU Load
+
+The current app runs Whisper once after capture stops. Realtime mode would run Whisper repeatedly while recording.
+
+This is much heavier. Tiny/base models may be practical. Larger models may introduce too much latency or CPU/GPU usage.
+
+### Model Context and Threading
+
+The current app stores a reusable `whisper_ctx` behind a mutex. Realtime dictation would likely need a long-running transcription worker that owns or carefully coordinates access to the Whisper context.
+
+The design should avoid blocking:
+
+- Hotkey handling.
+- UI event handling.
+- Audio capture callbacks.
+- Clipboard/paste output.
+
+### Output Into Arbitrary Apps
+
+The repo already has clipboard and paste support, but realtime typing raises new edge cases:
+
+- What if focus changes while dictating?
+- Should text continue going to the originally focused app or the current app?
+- What if paste fails midway?
+- Should output use clipboard paste, simulated key events, or both?
+- How should the app avoid destroying the user's clipboard for incremental output?
+
+The current final-paste path is simpler because it only writes once.
+
+## Likely Implementation Plan
+
+### Prototype
+
+Build a rough streaming mode while keeping the existing batch mode intact:
+
+1. Add a streaming capture path that sends audio chunks over a channel.
+2. Add a transcription worker started by `start_recording`.
+3. Accumulate 2-3 seconds of audio, resample, and transcribe.
+4. Use overlapping windows.
+5. Log or emit partial transcripts to the overlay first.
+6. Add basic deduplication against prior text.
+7. Commit stable text to clipboard/paste only after short silence or chunk boundaries.
+
+This would prove feasibility without committing to a perfect UX immediately.
+
+### Usable Dictation Mode
+
+After the prototype works:
+
+1. Add VAD or silence detection.
+2. Split text into partial and committed states.
+3. Tune chunk size and overlap by model size.
+4. Add settings for realtime mode vs current batch mode.
+5. Improve output behavior so text appears naturally in the target app.
+6. Handle cancellation, errors, and focus changes.
+
+### Polished System-Wide Dictation
+
+For a polished version:
+
+1. Add robust incremental transcript stabilization.
+2. Consider true keyboard event output for small text increments.
+3. Preserve and restore clipboard more carefully.
+4. Add platform-specific testing on macOS, Windows, and Linux.
+5. Add performance tuning by model.
+6. Add overlay UI for partial text and current dictation state.
+
+## Effort Estimate
+
+Prototype: 1-2 days.
+
+This would demonstrate chunked capture, repeated Whisper calls, and basic incremental output. It would likely have duplicate text and stability issues.
+
+Usable dictation mode: 4-7 days.
+
+This would include VAD, overlap handling, deduplication, committed-vs-partial text, cancellation, and a reasonable output path.
+
+Polished system-wide realtime dictation: 2-4 weeks.
+
+This would require careful UX, performance tuning, platform-specific behavior, focus edge cases, robust paste/typing behavior, and tests.
+
+## Initial Recommendation
+
+Treat this as a new realtime dictation mode, not as a small modification to the existing transcription command.
+
+The current batch mode should stay because it is simpler, accurate, and reliable. Realtime mode can be added alongside it with a separate capture/transcription worker pipeline.
+
+The first milestone should not try to type into arbitrary apps immediately. It should first stream partial text to the overlay or logs. Once chunking, latency, and deduplication are understood, then connect stable committed text to the existing clipboard/paste path.
+
+## Secondary Research Question
+
+The secondary question is whether an existing local Whisper project already provides system-wide realtime dictation.
+
+That should be researched separately, with attention to:
+
+- Whether it uses Whisper locally or a cloud API.
+- Whether it supports system-wide dictation into arbitrary apps.
+- Whether it solves incremental deduplication and partial commits.
+- Whether it supports macOS, Windows, and Linux.
+- Whether its architecture can be reused or studied for this app.

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "careless-whisper",
   "private": true,
   "version": "0.5.6",
+  "packageManager": "pnpm@10.33.2",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/poc/.gitignore
+++ b/poc/.gitignore
@@ -1,0 +1,5 @@
+audio/
+models/*.bin
+vendor/whisper.cpp/
+__pycache__/
+*.pyc

--- a/poc/README.md
+++ b/poc/README.md
@@ -1,0 +1,165 @@
+# Realtime Whisper POC
+
+This folder is a standalone proof of concept for chunked local dictation before
+integrating realtime transcription into the Tauri app.
+
+## What It Does
+
+- Records short microphone chunks with `ffmpeg`.
+- Transcribes each chunk with a local `whisper.cpp` build.
+- Prints recognized text to the terminal as each chunk finishes.
+
+This is intentionally not polished streaming dictation yet. It answers the
+first practical question: whether local chunked Whisper has acceptable latency
+and quality on this machine.
+
+## Local Setup
+
+The POC uses:
+
+- `vendor/whisper.cpp/` cloned from `ggerganov/whisper.cpp`.
+- `models/ggml-base.bin`, symlinked to the model already downloaded by the
+  installed Careless Whisper app.
+- `realtime_mic_poc.py`, a stdlib-only Python runner.
+
+## File Map
+
+Intentional POC files:
+
+- `README.md` - this overview and runbook.
+- `realtime_mic_poc.py` - chunked ffmpeg capture plus `whisper-cli`
+  transcription.
+- `run_whisper_stream.sh` - wrapper for the lower-latency `whisper-stream`
+  experiment.
+- `test_samples.md` - fixed English and Hebrew read-aloud paragraphs for
+  repeatable comparisons.
+- `.gitignore` - keeps generated audio, model binaries, vendored code, and
+  Python cache files out of git.
+
+Generated or external POC paths:
+
+- `audio/` - kept WAV/AIFF recordings from test runs; safe to delete when not
+  needed for comparison.
+- `models/ggml-base.bin` - symlink to the installed app's downloaded base
+  model.
+- `vendor/whisper.cpp/` - local clone/build of `ggerganov/whisper.cpp`.
+- `__pycache__/` - Python bytecode cache.
+
+Related tracking docs:
+
+- `../docs/realtime_whisper/plan.md`
+- `../docs/realtime_whisper/implementation_tracker.md`
+- `../docs/realtime_whisper/current_issues.md`
+- `../docs/realtime_whisper_discussion.md`
+
+## Run
+
+List macOS microphone devices:
+
+```sh
+python3 poc/realtime_mic_poc.py --list-devices
+```
+
+Start continuous capture using the MacBook Pro Microphone seen on this machine:
+
+```sh
+python3 poc/realtime_mic_poc.py
+```
+
+This is the preferred runner now. It keeps ffmpeg recording while Whisper
+transcribes previous chunks, avoiding the word-loss gap from the original
+sequential POC.
+
+For Hebrew comparison:
+
+```sh
+python3 poc/realtime_mic_poc.py --language he
+```
+
+Press `Ctrl+C` to stop.
+
+For consistent comparisons, use the fixed read-aloud paragraphs in
+`poc/test_samples.md`.
+
+## Lower-Latency Stream Test
+
+`whisper-stream` is also built locally. Unlike the Python chunk runner, it keeps
+the model loaded and captures continuously through SDL2:
+
+```sh
+poc/run_whisper_stream.sh
+```
+
+For Hebrew comparison:
+
+```sh
+poc/run_whisper_stream.sh -l he
+```
+
+SDL2 capture IDs do not necessarily match ffmpeg/AVFoundation IDs. If the
+default device is wrong, inspect the capture devices printed during startup and
+then pin one:
+
+```sh
+poc/run_whisper_stream.sh --capture N
+```
+
+Stop it with `Ctrl+C`.
+
+By default the POC runs `whisper.cpp` on CPU because that is the most reliable
+first smoke test from a terminal. Add `--gpu` to try the Metal path:
+
+```sh
+python3 poc/realtime_mic_poc.py --gpu
+```
+
+To compare against the older sequential mode:
+
+```sh
+python3 poc/realtime_mic_poc.py --capture-mode chunked --gpu
+```
+
+Each chunk prints basic audio levels:
+
+```text
+[0001] 4.8s | record=3.0s whisper=1.8s | audio=3.0s rms=-28.4dBFS peak=-7.2dBFS nonzero=48000
+TEXT [0001]: Hello, this is a short test for real time dictation.
+```
+
+The POC prints text in the terminal only. It does not paste into another app or
+show the app overlay yet. At the end of the run it prints a combined
+`FULL TRANSCRIPT` block.
+
+If RMS is around `-50dBFS` or lower while you are speaking, the selected device
+is probably wrong, muted, or too quiet. The runner skips very quiet chunks by
+default to avoid Whisper hallucinating on silence. To force transcription of
+every chunk:
+
+```sh
+python3 poc/realtime_mic_poc.py --language he --gpu --no-silence-skip
+```
+
+If the output says `all-zero audio` or `nonzero=0`, ffmpeg recorded digital
+silence. Check:
+
+- System Settings -> Privacy & Security -> Microphone has Terminal/iTerm enabled.
+- `python3 poc/realtime_mic_poc.py --list-devices` shows the device you expect.
+- The `--device ':N'` audio index matches the real microphone.
+
+On this Mac, the relevant devices seen so far were:
+
+- `:0` - Virtual Desktop Speakers, not a microphone for this POC.
+- `:1` - MacBook Pro Microphone.
+- `:2` - Virtual Desktop Mic.
+
+The runner defaults to `:1` for this machine.
+
+## Notes
+
+- macOS may prompt for microphone access for the terminal app.
+- The Codex sandbox may not expose microphone devices; run the mic command from
+  your normal Terminal/iTerm session if `--list-devices` is empty here.
+- The default chunk size is 3 seconds, so text appears after each chunk and its
+  transcription complete.
+- If the wrong mic is used, run `--list-devices` and pass the audio index as
+  `--device ':N'`.

--- a/poc/realtime_mic_poc.py
+++ b/poc/realtime_mic_poc.py
@@ -1,0 +1,507 @@
+#!/usr/bin/env python3
+"""Chunked microphone-to-Whisper proof of concept.
+
+This intentionally keeps the POC outside the Tauri app. It records short audio
+windows with ffmpeg, runs whisper.cpp on each WAV file, and prints transcripts.
+"""
+
+from __future__ import annotations
+
+import argparse
+import math
+import os
+import queue
+import shutil
+import subprocess
+import sys
+import threading
+import time
+import wave
+from array import array
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parent
+DEFAULT_WHISPER = ROOT / "vendor" / "whisper.cpp" / "build" / "bin" / "whisper-cli"
+DEFAULT_MODEL = ROOT / "models" / "ggml-base.bin"
+DEFAULT_AUDIO_DIR = ROOT / "audio"
+SAMPLE_RATE = 16000
+CHANNELS = 1
+BYTES_PER_SAMPLE = 2
+
+
+def require_file(path: Path, label: str) -> None:
+    if not path.exists():
+        raise SystemExit(f"{label} not found: {path}")
+
+
+def require_exe(name: str) -> str:
+    path = shutil.which(name)
+    if not path:
+        raise SystemExit(f"Missing required executable on PATH: {name}")
+    return path
+
+
+def list_devices(ffmpeg: str) -> int:
+    cmd = [
+        ffmpeg,
+        "-hide_banner",
+        "-f",
+        "avfoundation",
+        "-list_devices",
+        "true",
+        "-i",
+        "",
+    ]
+    subprocess.run(cmd, check=False)
+    return 0
+
+
+def record_chunk(
+    ffmpeg: str,
+    device: str,
+    seconds: float,
+    output_path: Path,
+) -> None:
+    cmd = [
+        ffmpeg,
+        "-hide_banner",
+        "-nostdin",
+        "-loglevel",
+        "error",
+        "-f",
+        "avfoundation",
+        "-i",
+        device,
+        "-t",
+        f"{seconds:.3f}",
+        "-ac",
+        "1",
+        "-ar",
+        "16000",
+        "-c:a",
+        "pcm_s16le",
+        "-y",
+        str(output_path),
+    ]
+    result = subprocess.run(cmd, check=False)
+    if result.returncode != 0:
+        raise RuntimeError(
+            "ffmpeg could not record from the microphone. "
+            "Run with --list-devices, check --device, and confirm macOS "
+            "microphone permission for your terminal."
+        )
+
+
+def start_continuous_capture(ffmpeg: str, device: str) -> subprocess.Popen[bytes]:
+    cmd = [
+        ffmpeg,
+        "-hide_banner",
+        "-nostdin",
+        "-loglevel",
+        "error",
+        "-f",
+        "avfoundation",
+        "-i",
+        device,
+        "-ac",
+        str(CHANNELS),
+        "-ar",
+        str(SAMPLE_RATE),
+        "-f",
+        "s16le",
+        "-c:a",
+        "pcm_s16le",
+        "-",
+    ]
+    return subprocess.Popen(
+        cmd,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.DEVNULL,
+    )
+
+
+def read_exact(stream, size: int) -> bytes:
+    parts: list[bytes] = []
+    remaining = size
+    while remaining > 0:
+        chunk = stream.read(remaining)
+        if not chunk:
+            break
+        parts.append(chunk)
+        remaining -= len(chunk)
+    return b"".join(parts)
+
+
+def write_wav(audio_path: Path, pcm_bytes: bytes) -> None:
+    with wave.open(str(audio_path), "wb") as wav:
+        wav.setnchannels(CHANNELS)
+        wav.setsampwidth(BYTES_PER_SAMPLE)
+        wav.setframerate(SAMPLE_RATE)
+        wav.writeframes(pcm_bytes)
+
+
+def continuous_capture_reader(
+    process: subprocess.Popen[bytes],
+    chunk_bytes: int,
+    chunks,
+    stop_event: threading.Event,
+) -> None:
+    assert process.stdout is not None
+    chunk_index = 0
+    while not stop_event.is_set():
+        pcm_bytes = read_exact(process.stdout, chunk_bytes)
+        if len(pcm_bytes) < chunk_bytes:
+            break
+        chunk_index += 1
+        chunks.put((chunk_index, pcm_bytes, time.time()))
+
+
+def dbfs(value: float) -> float:
+    if value <= 0:
+        return float("-inf")
+    return 20.0 * math.log10(value / 32768.0)
+
+
+def format_db(value: float) -> str:
+    if math.isinf(value):
+        return "-inf"
+    return f"{value:.1f}"
+
+
+def audio_stats(audio_path: Path) -> tuple[float, float, float, int]:
+    with wave.open(str(audio_path), "rb") as wav:
+        frame_count = wav.getnframes()
+        sample_rate = wav.getframerate()
+        sample_width = wav.getsampwidth()
+        raw = wav.readframes(frame_count)
+
+    if sample_width != 2:
+        raise RuntimeError(f"Expected 16-bit PCM WAV, got sample width {sample_width}")
+
+    samples = array("h")
+    samples.frombytes(raw)
+    if sys.byteorder != "little":
+        samples.byteswap()
+
+    if not samples:
+        return 0.0, float("-inf"), float("-inf"), 0
+
+    nonzero = sum(1 for sample in samples if sample)
+    peak = max(abs(sample) for sample in samples)
+    rms = math.sqrt(sum(sample * sample for sample in samples) / len(samples))
+    duration = frame_count / sample_rate if sample_rate else 0.0
+    return duration, dbfs(rms), dbfs(float(peak)), nonzero
+
+
+def transcribe_chunk(
+    whisper: Path,
+    model: Path,
+    audio_path: Path,
+    language: str,
+    threads: int,
+    use_gpu: bool,
+    no_speech_threshold: float,
+) -> str:
+    cmd = [
+        str(whisper),
+        "-m",
+        str(model),
+        "-f",
+        str(audio_path),
+        "-l",
+        language,
+        "-t",
+        str(threads),
+        "-nt",
+        "-np",
+        "-sns",
+        "-nth",
+        str(no_speech_threshold),
+    ]
+    if not use_gpu:
+        cmd.append("-ng")
+    result = subprocess.run(cmd, check=False, capture_output=True, text=True)
+    if result.returncode != 0:
+        raise RuntimeError(result.stderr.strip() or "whisper-cli failed")
+    return " ".join(result.stdout.split())
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Record microphone chunks and transcribe them with local whisper.cpp."
+    )
+    parser.add_argument(
+        "--list-devices",
+        action="store_true",
+        help="List macOS AVFoundation capture devices and exit.",
+    )
+    parser.add_argument(
+        "--device",
+        default=":1",
+        help="AVFoundation input selector. On this Mac, ':1' is the MacBook Pro Microphone.",
+    )
+    parser.add_argument(
+        "--chunk-seconds",
+        type=float,
+        default=3.0,
+        help="Seconds of audio per transcription chunk.",
+    )
+    parser.add_argument(
+        "--capture-mode",
+        choices=("continuous", "chunked"),
+        default="continuous",
+        help="continuous keeps recording while Whisper transcribes; chunked is the older sequential ffmpeg mode.",
+    )
+    parser.add_argument(
+        "--language",
+        default="en",
+        help="Whisper language code, for example 'en', 'he', or 'auto'.",
+    )
+    parser.add_argument(
+        "--threads",
+        type=int,
+        default=max(2, min(8, (os.cpu_count() or 4) // 2)),
+        help="Whisper compute threads.",
+    )
+    parser.add_argument(
+        "--gpu",
+        action="store_true",
+        help="Allow whisper.cpp to use the GPU/Metal backend. CPU is the default for POC stability.",
+    )
+    parser.add_argument(
+        "--min-rms-dbfs",
+        type=float,
+        default=-50.0,
+        help="Skip Whisper for chunks quieter than this RMS dBFS level.",
+    )
+    parser.add_argument(
+        "--no-silence-skip",
+        action="store_true",
+        help="Always send chunks to Whisper, even if recorded audio looks silent.",
+    )
+    parser.add_argument(
+        "--no-speech-threshold",
+        type=float,
+        default=0.30,
+        help="Whisper no-speech threshold. Lower is more aggressive about silence.",
+    )
+    parser.add_argument(
+        "--max-chunks",
+        type=int,
+        default=0,
+        help="Stop after this many chunks. 0 means run until Ctrl+C.",
+    )
+    parser.add_argument(
+        "--keep-audio",
+        action="store_true",
+        help="Keep recorded WAV chunks under poc/audio for inspection.",
+    )
+    parser.add_argument(
+        "--queue-size",
+        type=int,
+        default=16,
+        help="Maximum captured chunks to queue in continuous mode before applying backpressure.",
+    )
+    parser.add_argument(
+        "--whisper",
+        type=Path,
+        default=DEFAULT_WHISPER,
+        help="Path to whisper-cli.",
+    )
+    parser.add_argument(
+        "--model",
+        type=Path,
+        default=DEFAULT_MODEL,
+        help="Path to a ggml Whisper model.",
+    )
+    parser.add_argument(
+        "--audio-dir",
+        type=Path,
+        default=DEFAULT_AUDIO_DIR,
+        help="Directory for temporary WAV chunks.",
+    )
+    return parser.parse_args()
+
+
+def process_recorded_chunk(
+    args: argparse.Namespace,
+    audio_path: Path,
+    chunk_index: int,
+    started: float,
+    recording_elapsed: float,
+    queue_age: float | None = None,
+) -> str | None:
+    duration, rms, peak, nonzero = audio_stats(audio_path)
+    audio_summary = (
+        f"audio={duration:.1f}s rms={format_db(rms)}dBFS "
+        f"peak={format_db(peak)}dBFS nonzero={nonzero}"
+    )
+    queue_summary = f" queue={queue_age:.1f}s" if queue_age is not None else ""
+    if nonzero == 0:
+        elapsed = time.time() - started
+        print(
+            f"[{chunk_index:04d}] {elapsed:.1f}s | "
+            f"record={recording_elapsed:.1f}s{queue_summary} | "
+            f"<all-zero audio: {audio_summary}. "
+            "Check mic permission or --device index.>",
+            flush=True,
+        )
+        return None
+    if not args.no_silence_skip and rms < args.min_rms_dbfs:
+        elapsed = time.time() - started
+        print(
+            f"[{chunk_index:04d}] {elapsed:.1f}s | "
+            f"record={recording_elapsed:.1f}s{queue_summary} | "
+            f"<skipped quiet chunk: {audio_summary}>",
+            flush=True,
+        )
+        return None
+
+    transcribe_started = time.time()
+    text = transcribe_chunk(
+        args.whisper,
+        args.model,
+        audio_path,
+        args.language,
+        args.threads,
+        args.gpu,
+        args.no_speech_threshold,
+    )
+    transcribe_elapsed = time.time() - transcribe_started
+    elapsed = time.time() - started
+    if text:
+        print(
+            f"[{chunk_index:04d}] {elapsed:.1f}s | "
+            f"record={recording_elapsed:.1f}s "
+            f"whisper={transcribe_elapsed:.1f}s{queue_summary} | "
+            f"{audio_summary}",
+            flush=True,
+        )
+        print(
+            f"TEXT [{chunk_index:04d}]: {text}",
+            flush=True,
+        )
+        return text
+
+    print(
+        f"[{chunk_index:04d}] {elapsed:.1f}s | "
+        f"record={recording_elapsed:.1f}s "
+        f"whisper={transcribe_elapsed:.1f}s{queue_summary} | "
+        f"{audio_summary} | <no speech>",
+        flush=True,
+    )
+    return None
+
+
+def main() -> int:
+    args = parse_args()
+    ffmpeg = require_exe("ffmpeg")
+
+    if args.list_devices:
+        return list_devices(ffmpeg)
+
+    require_file(args.whisper, "whisper-cli")
+    require_file(args.model, "Whisper model")
+
+    args.audio_dir.mkdir(parents=True, exist_ok=True)
+    print(
+        "Recording chunks. Speak into the selected mic; press Ctrl+C to stop.",
+        flush=True,
+    )
+    print(
+        f"device={args.device} chunk={args.chunk_seconds:.1f}s "
+        f"mode={args.capture_mode} language={args.language} gpu={args.gpu} "
+        f"min_rms={format_db(args.min_rms_dbfs)}dBFS model={args.model}",
+        flush=True,
+    )
+
+    chunk_index = 0
+    transcript_parts: list[str] = []
+    stop_event = threading.Event()
+    capture_process: subprocess.Popen[bytes] | None = None
+    reader_thread: threading.Thread | None = None
+    try:
+        if args.capture_mode == "continuous":
+            chunk_bytes = int(args.chunk_seconds * SAMPLE_RATE * CHANNELS * BYTES_PER_SAMPLE)
+            chunks = queue.Queue(maxsize=max(1, args.queue_size))
+            capture_process = start_continuous_capture(ffmpeg, args.device)
+            reader_thread = threading.Thread(
+                target=continuous_capture_reader,
+                args=(capture_process, chunk_bytes, chunks, stop_event),
+                daemon=True,
+            )
+            reader_thread.start()
+            print("continuous capture active; speak normally.", flush=True)
+
+            while args.max_chunks <= 0 or chunk_index < args.max_chunks:
+                try:
+                    queued_index, pcm_bytes, captured_at = chunks.get(timeout=0.5)
+                except queue.Empty:
+                    if capture_process.poll() is not None:
+                        raise RuntimeError(
+                            "ffmpeg continuous capture exited before producing audio. "
+                            "Check microphone permission and --device."
+                        )
+                    continue
+                chunk_index = queued_index
+                started = time.time()
+                audio_path = args.audio_dir / f"chunk-{chunk_index:04d}.wav"
+                write_wav(audio_path, pcm_bytes)
+                text = process_recorded_chunk(
+                    args,
+                    audio_path,
+                    chunk_index,
+                    started,
+                    args.chunk_seconds,
+                    queue_age=started - captured_at,
+                )
+                if text:
+                    transcript_parts.append(text)
+                if not args.keep_audio:
+                    audio_path.unlink(missing_ok=True)
+        else:
+            while args.max_chunks <= 0 or chunk_index < args.max_chunks:
+                chunk_index += 1
+                audio_path = args.audio_dir / f"chunk-{chunk_index:04d}.wav"
+                started = time.time()
+                print(f"[{chunk_index:04d}] recording...", flush=True)
+                recording_started = time.time()
+                record_chunk(ffmpeg, args.device, args.chunk_seconds, audio_path)
+                recording_elapsed = time.time() - recording_started
+                text = process_recorded_chunk(
+                    args,
+                    audio_path,
+                    chunk_index,
+                    started,
+                    recording_elapsed,
+                )
+                if text:
+                    transcript_parts.append(text)
+                if not args.keep_audio:
+                    audio_path.unlink(missing_ok=True)
+    except KeyboardInterrupt:
+        print("\nStopped.", flush=True)
+    except RuntimeError as error:
+        print(f"error: {error}", file=sys.stderr)
+        return 1
+    finally:
+        stop_event.set()
+        if capture_process is not None and capture_process.poll() is None:
+            capture_process.terminate()
+            try:
+                capture_process.wait(timeout=2)
+            except subprocess.TimeoutExpired:
+                capture_process.kill()
+        if reader_thread is not None:
+            reader_thread.join(timeout=1)
+
+    if transcript_parts:
+        print("\nFULL TRANSCRIPT:", flush=True)
+        print(" ".join(transcript_parts), flush=True)
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/poc/run_whisper_stream.sh
+++ b/poc/run_whisper_stream.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+exec poc/vendor/whisper.cpp/build/bin/whisper-stream \
+  -m poc/models/ggml-base.bin \
+  -l en \
+  -t 6 \
+  --step 500 \
+  --length 5000 \
+  --keep 500 \
+  "$@"

--- a/poc/test_samples.md
+++ b/poc/test_samples.md
@@ -1,0 +1,54 @@
+# Realtime Whisper Test Samples
+
+Use these fixed read-aloud samples when comparing chunk size, GPU/CPU, stream
+mode, model size, and Hebrew vs English quality. Read at a normal speaking pace
+and try to keep the microphone distance consistent between runs.
+
+For scoring, ignore punctuation and minor capitalization differences. Focus on
+missing words, substituted words, repeated phrases, and latency.
+
+## Hebrew Sample
+
+שלום, זהו מבחן קצר למערכת הכתבה בזמן אמת. אני מדבר בקצב רגיל, בלי למהר, ובודק אם המילים מופיעות בצורה ברורה. היום אנחנו בוחנים הקלטה מהמיקרופון, זיהוי דיבור בעברית, וזמן תגובה בין סוף המשפט לבין הופעת הטקסט. אם המשפט הזה נקלט כמו שצריך, אפשר להמשיך לשלב הבא של הניסוי.
+
+## English Sample
+
+Hello, this is a short test for real time dictation. I am speaking at a normal pace, without rushing, and checking whether the words appear clearly. Today we are testing microphone capture, local Whisper transcription, and the delay between the end of a sentence and the moment the text appears. If this paragraph is captured correctly, we can move to the next stage of the experiment.
+
+## Suggested Runs
+
+Run English first as the control case. It should be easier to judge whether the
+pipeline works before tuning Hebrew.
+
+Continuous-capture English baseline:
+
+```sh
+python3 poc/realtime_mic_poc.py --gpu --chunk-seconds 5 --max-chunks 8 --keep-audio
+```
+
+Older sequential-capture comparison:
+
+```sh
+python3 poc/realtime_mic_poc.py --capture-mode chunked --gpu --chunk-seconds 5 --max-chunks 8 --keep-audio
+```
+
+Stream English baseline:
+
+```sh
+poc/run_whisper_stream.sh
+```
+
+Continuous-capture Hebrew comparison:
+
+```sh
+python3 poc/realtime_mic_poc.py --language he --gpu --chunk-seconds 5 --max-chunks 8 --keep-audio
+```
+
+Stream Hebrew comparison:
+
+```sh
+poc/run_whisper_stream.sh -l he
+```
+
+Capture the command output after each run and compare it to the expected sample
+text above.

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -47,6 +47,8 @@ libc = "0.2"
 # unusably slow at opt-level 0. This keeps debug info but enables optimizations.
 [profile.dev]
 opt-level = 2
+# Avoid intermittent macOS arm64 linker failures in optimized dev builds.
+incremental = false
 
 [dev-dependencies]
 hound = "3.5"

--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -7,6 +7,8 @@
     "core:default",
     "core:event:default",
     "core:window:default",
+    "core:window:allow-set-size",
+    "core:window:allow-start-dragging",
     "core:tray:default",
     "opener:default",
     "dialog:allow-open",

--- a/src-tauri/src/audio/capture.rs
+++ b/src-tauri/src/audio/capture.rs
@@ -30,7 +30,10 @@ pub fn start_capture(max_seconds: u32) -> Result<RecordingHandle, String> {
 
     log::info!(
         "[audio] device='{}', sample_rate={}, channels={}, max_seconds={}",
-        device_name, sample_rate, channels, max_seconds
+        device_name,
+        sample_rate,
+        channels,
+        max_seconds
     );
 
     let samples: Arc<Mutex<Vec<f32>>> = Arc::new(Mutex::new(Vec::new()));
@@ -76,7 +79,10 @@ pub fn stop_capture(handle: RecordingHandle) -> (Vec<f32>, u32, u16) {
     let duration_secs = samples.len() as f32 / (sample_rate as f32 * channels as f32);
     log::info!(
         "[audio] stopped: {} samples, {:.1}s, rate={}, channels={}",
-        samples.len(), duration_secs, sample_rate, channels
+        samples.len(),
+        duration_secs,
+        sample_rate,
+        channels
     );
     // Dropping handle stops the stream.
     (samples, sample_rate, channels)

--- a/src-tauri/src/audio/decode.rs
+++ b/src-tauri/src/audio/decode.rs
@@ -184,7 +184,9 @@ mod tests {
         let result = decode_audio_file(&path);
         assert!(result.is_err());
         assert!(
-            result.unwrap_err().contains("did not contain any decodable audio"),
+            result
+                .unwrap_err()
+                .contains("did not contain any decodable audio"),
             "expected empty audio error"
         );
     }

--- a/src-tauri/src/audio/resample.rs
+++ b/src-tauri/src/audio/resample.rs
@@ -83,7 +83,7 @@ mod tests {
         let samples: Vec<f32> = (0..num_samples).map(|i| (i as f32 * 0.001).sin()).collect();
         let result = resample_to_16k(samples, 44100, 1).unwrap();
         let expected_len = 16000; // ~1 second at 16kHz
-        // Allow some tolerance due to resampler padding
+                                  // Allow some tolerance due to resampler padding
         let ratio = result.len() as f64 / expected_len as f64;
         assert!(ratio > 0.9 && ratio < 1.2, "ratio was {}", ratio);
     }

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -1,6 +1,7 @@
 use std::path::PathBuf;
 use std::sync::atomic::{AtomicBool, Ordering};
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
 
 use tauri::{AppHandle, Emitter, Manager, State};
 use tauri_plugin_autostart::ManagerExt;
@@ -10,19 +11,34 @@ use crate::models::downloader::{self, ModelInfo};
 use crate::output::paste::FocusTarget;
 use crate::AppState;
 
+const OVERLAY_WIDTH: f64 = 360.0;
+const OVERLAY_BASE_HEIGHT: f64 = 120.0;
+
+fn preview_text(text: &str, max_chars: usize) -> String {
+    let mut chars = text.chars();
+    let mut preview = String::new();
+
+    for _ in 0..max_chars {
+        match chars.next() {
+            Some(ch) => preview.push(ch),
+            None => return preview,
+        }
+    }
+
+    if chars.next().is_some() {
+        preview.push_str("...");
+    }
+
+    preview
+}
+
 fn position_overlay(app: &AppHandle, win: &tauri::WebviewWindow, position: &OverlayPosition) {
     use tauri::PhysicalPosition;
 
     // Find the monitor the user is actually working on (cursor's monitor).
-    // Notes on Tauri 2.x + macOS coordinate quirks:
-    //   - `monitor_from_point` is unreliable on macOS — we hit-test manually.
-    //   - `monitor.position()` is in primary-scale logical points, but
-    //     `monitor.size()` is in physical pixels. Dividing by scale gives
-    //     logical size, which lines up with the cursor coordinate space.
-    //   - Cursor Y values don't always line up cleanly across displays with
-    //     different heights, so we do an X-only hit test — this reliably
-    //     picks the right monitor for the vast majority of arrangements
-    //     (side-by-side) and falls back gracefully otherwise.
+    // Tauri/macOS mixed-DPI coordinates are easiest to keep stable if we use
+    // the monitor-reported origin/size directly and avoid multiplying external
+    // monitor origins by the primary display scale.
     let cursor_pos = app.cursor_position().ok();
     let monitors = app.available_monitors().unwrap_or_default();
     for (i, m) in monitors.iter().enumerate() {
@@ -35,24 +51,13 @@ fn position_overlay(app: &AppHandle, win: &tauri::WebviewWindow, position: &Over
         );
     }
 
-    // Primary monitor's scale factor is the reference for the whole "logical"
-    // coordinate space — monitor positions are in primary-logical points, but
-    // cursor_position() returns true physical pixels on the virtual desktop.
-    // We need to convert origins to physical to hit-test correctly.
-    let primary_scale = monitors
-        .iter()
-        .find(|m| m.position().x == 0 && m.position().y == 0)
-        .map(|m| m.scale_factor())
-        .or_else(|| app.primary_monitor().ok().flatten().map(|m| m.scale_factor()))
-        .unwrap_or(1.0);
-
     // X-only hit test with a nearest-monitor fallback. Cursor coords can drift
     // a few dozen pixels outside the reported monitor bounds (bezel, rounding,
     // coordinate-system mismatches), so pick the monitor whose X range is
     // closest to the cursor if no monitor contains it exactly.
     let cursor_monitor = cursor_pos.as_ref().and_then(|pos| {
         let x_distance = |m: &tauri::Monitor| -> f64 {
-            let left = m.position().x as f64 * primary_scale;
+            let left = m.position().x as f64;
             let right = left + m.size().width as f64;
             if pos.x < left {
                 left - pos.x
@@ -73,9 +78,8 @@ fn position_overlay(app: &AppHandle, win: &tauri::WebviewWindow, position: &Over
     });
 
     log::info!(
-        "[overlay] cursor={:?}, primary_scale={}, hit_monitor_origin={:?}",
+        "[overlay] cursor={:?}, hit_monitor_origin={:?}",
         cursor_pos,
-        primary_scale,
         cursor_monitor.as_ref().map(|m| m.position())
     );
 
@@ -91,49 +95,37 @@ fn position_overlay(app: &AppHandle, win: &tauri::WebviewWindow, position: &Over
         }
     };
 
-    // Work in macOS NSScreen points (same units as monitor.position()), then
-    // multiply by primary_scale at the end — Tauri's PhysicalPosition is
-    // effectively `NSScreen-points × primary_scale` on macOS, so that's what
-    // we feed it.
     let target_scale = monitor.scale_factor();
-    let origin_x_points = monitor.position().x as f64;
-    let origin_y_points = monitor.position().y as f64;
-    // NSScreen width is reported_physical_size / target_scale (size field is
-    // in physical pixels, but NSScreen frames live in points).
-    let screen_w_points = monitor.size().width as f64 / target_scale;
-    let screen_h_points = monitor.size().height as f64 / target_scale;
+    let origin_x = monitor.position().x as f64;
+    let origin_y = monitor.position().y as f64;
+    let screen_w = monitor.size().width as f64;
+    let screen_h = monitor.size().height as f64;
 
-    let overlay_w = 320.0;
-    let overlay_h = 80.0;
-    let margin = 16.0;
-    let top_offset = 40.0;
+    let overlay_w = OVERLAY_WIDTH * target_scale;
+    let overlay_h = OVERLAY_BASE_HEIGHT * target_scale;
+    let margin = 16.0 * target_scale;
+    let top_offset = 40.0 * target_scale;
 
     let offset_x = match position {
         OverlayPosition::TopLeft => margin,
-        OverlayPosition::TopRight => screen_w_points - overlay_w - margin,
-        OverlayPosition::TopCenter | OverlayPosition::BottomCenter => {
-            (screen_w_points - overlay_w) / 2.0
-        }
+        OverlayPosition::TopRight => screen_w - overlay_w - margin,
+        OverlayPosition::TopCenter | OverlayPosition::BottomCenter => (screen_w - overlay_w) / 2.0,
     };
     let offset_y = match position {
-        OverlayPosition::BottomCenter => screen_h_points - overlay_h - margin,
+        OverlayPosition::BottomCenter => screen_h - overlay_h - margin,
         _ => top_offset,
     };
 
-    let x_points = origin_x_points + offset_x;
-    let y_points = origin_y_points + offset_y;
-    let x_phys = x_points * primary_scale;
-    let y_phys = y_points * primary_scale;
+    let x_phys = origin_x + offset_x;
+    let y_phys = origin_y + offset_y;
 
     log::info!(
-        "[overlay] target_origin_pts=({}, {}), {}x{} pts @ {}x, overlay_pts=({}, {}), phys=({}, {}), position={:?}",
-        origin_x_points,
-        origin_y_points,
-        screen_w_points,
-        screen_h_points,
+        "[overlay] target_origin=({}, {}), {}x{} px @ {}x, overlay_px=({}, {}), position={:?}",
+        origin_x,
+        origin_y,
+        screen_w,
+        screen_h,
         target_scale,
-        x_points,
-        y_points,
         x_phys,
         y_phys,
         position
@@ -149,8 +141,14 @@ fn set_overlay_above_dock(win: &tauri::WebviewWindow) {
     unsafe {
         if let Ok(ns_win) = win.ns_window() {
             let ns_win = ns_win as *mut objc2::runtime::AnyObject;
-            // kCGStatusWindowLevel = 25, above kCGDockWindowLevel (20)
+            // kCGStatusWindowLevel = 25, above kCGDockWindowLevel (20).
             let _: () = msg_send![ns_win, setLevel: 25_i64];
+            // Join all Spaces and appear as a fullscreen auxiliary window so
+            // the overlay can stay visible when the target app is fullscreen.
+            let collection_behavior: u64 = (1 << 0) | (1 << 4) | (1 << 8);
+            let _: () = msg_send![ns_win, setCollectionBehavior: collection_behavior];
+            let _: () = msg_send![ns_win, setCanHide: false];
+            let _: () = msg_send![ns_win, orderFrontRegardless];
         }
     }
 }
@@ -167,6 +165,33 @@ fn emit_transcription_error(app: &AppHandle, message: impl Into<String>) {
         "transcription-error",
         serde_json::json!({ "message": message }),
     );
+}
+
+fn emit_backend_error(app: &AppHandle, message: impl Into<String>) {
+    let message = message.into();
+    let _ = app.emit("backend-error", serde_json::json!({ "message": message }));
+}
+
+fn emit_realtime_transcription(app: &AppHandle, text: &str, full_text: &str) {
+    let _ = app.emit(
+        "realtime-transcription",
+        serde_json::json!({ "text": text, "full_text": full_text }),
+    );
+}
+
+fn emit_realtime_mode_updated(app: &AppHandle, armed: bool, active: bool) {
+    let _ = app.emit(
+        "realtime-mode-updated",
+        serde_json::json!({ "armed": armed, "active": active }),
+    );
+}
+
+fn sample_rms(samples: &[f32]) -> f32 {
+    if samples.is_empty() {
+        return 0.0;
+    }
+    let sum: f32 = samples.iter().map(|sample| sample * sample).sum();
+    (sum / samples.len() as f32).sqrt()
 }
 
 fn transcription_inputs(
@@ -212,6 +237,7 @@ fn spawn_transcription(
             return;
         }
 
+        let _transcription_guard = state.transcription_lock.lock().unwrap();
         let ctx = state.whisper_ctx.lock().unwrap().take();
         let ctx = match ctx {
             Some(context) => context,
@@ -227,24 +253,21 @@ fn spawn_transcription(
             },
         };
 
-        let result = crate::transcribe::whisper::transcribe(&ctx, &samples_16k, &language, translate_to_english);
+        let result = crate::transcribe::whisper::transcribe(
+            &ctx,
+            &samples_16k,
+            &language,
+            translate_to_english,
+        );
         *state.whisper_ctx.lock().unwrap() = Some(ctx);
 
         match result {
             Ok(ref text) => {
-                log::info!("[transcribe] result ({} chars): {:?}", text.len(), &text[..text.len().min(100)]);
-
-                // Save the user's clipboard before overwriting it
-                let previous_clipboard = crate::output::clipboard::read_clipboard();
-
-                let clipboard_ok = match crate::output::clipboard::copy_to_clipboard(text) {
-                    Ok(()) => true,
-                    Err(e) => {
-                        log::error!("[clipboard] failed: {}", e);
-                        emit_transcription_error(&app, format!("Clipboard error: {}", e));
-                        false
-                    }
-                };
+                log::info!(
+                    "[transcribe] result ({} chars): {:?}",
+                    text.chars().count(),
+                    preview_text(text, 100)
+                );
 
                 if hide_overlay_on_finish {
                     hide_overlay(&app);
@@ -255,24 +278,38 @@ fn spawn_transcription(
                     serde_json::json!({ "text": text }),
                 );
 
-                if clipboard_ok && auto_paste {
-                    if let Some(target) = target_focus {
-                        match crate::output::paste::paste_into_target(target) {
-                            Ok(()) => {
-                                // Paste succeeded — restore the user's original clipboard
-                                if let Some(prev) = previous_clipboard {
-                                    std::thread::sleep(std::time::Duration::from_millis(200));
-                                    let _ = crate::output::clipboard::copy_to_clipboard(&prev);
+                if auto_paste {
+                    match target_focus {
+                        Some(target) => {
+                            if let Err(error) =
+                                crate::output::paste::type_text_into_target(target, text)
+                            {
+                                log::error!("[type] failed: {}", error);
+                                if let Err(clipboard_error) =
+                                    crate::output::clipboard::copy_to_clipboard(text)
+                                {
+                                    log::error!("[clipboard] failed: {}", clipboard_error);
+                                    emit_transcription_error(
+                                        &app,
+                                        format!("Clipboard error: {}", clipboard_error),
+                                    );
                                 }
                             }
-                            Err(error) => {
-                                // Paste failed — keep transcription on clipboard so user can Cmd+V manually
-                                log::error!("[paste] failed: {}", error);
+                        }
+                        None => {
+                            log::warn!("[type] no target window captured — copying transcript");
+                            if let Err(error) = crate::output::clipboard::copy_to_clipboard(text) {
+                                log::error!("[clipboard] failed: {}", error);
+                                emit_transcription_error(
+                                    &app,
+                                    format!("Clipboard error: {}", error),
+                                );
                             }
                         }
-                    } else {
-                        log::warn!("[paste] no target window captured — skipping paste");
                     }
+                } else if let Err(error) = crate::output::clipboard::copy_to_clipboard(text) {
+                    log::error!("[clipboard] failed: {}", error);
+                    emit_transcription_error(&app, format!("Clipboard error: {}", error));
                 }
             }
             Err(ref error) => {
@@ -284,6 +321,249 @@ fn spawn_transcription(
             }
         }
     });
+}
+
+fn transcribe_realtime_chunk(
+    app: &AppHandle,
+    samples_16k: &[f32],
+    language: &str,
+    translate_to_english: bool,
+    active_model: &str,
+    model_path: &PathBuf,
+) -> Result<String, String> {
+    let state = app.state::<AppState>();
+    let _transcription_guard = state.transcription_lock.lock().unwrap();
+
+    downloader::validate_model_file(active_model)?;
+
+    let ctx = state.whisper_ctx.lock().unwrap().take();
+    let ctx = match ctx {
+        Some(context) => context,
+        None => crate::transcribe::whisper::load_model(model_path)?,
+    };
+
+    let result =
+        crate::transcribe::whisper::transcribe(&ctx, samples_16k, language, translate_to_english);
+    *state.whisper_ctx.lock().unwrap() = Some(ctx);
+    result
+}
+
+fn spawn_realtime_transcription_worker(
+    app: AppHandle,
+    active: Arc<AtomicBool>,
+    samples: Arc<Mutex<Vec<f32>>>,
+    sample_rate: u32,
+    channels: u16,
+    settings: Settings,
+    target_focus: Option<FocusTarget>,
+    start_sample_index: usize,
+    output_seen: Arc<AtomicBool>,
+) {
+    std::thread::spawn(move || {
+        const CHUNK_SECONDS: f32 = 4.0;
+        const POLL_MS: u64 = 500;
+        const MIN_RMS: f32 = 0.003;
+
+        let channels_usize = channels as usize;
+        let raw_chunk_len = (sample_rate as f32 * channels as f32 * CHUNK_SECONDS).round() as usize;
+        let model_path = downloader::model_path(&settings.active_model);
+        let mut next_sample_index = start_sample_index;
+        let mut full_text = String::new();
+
+        log::info!(
+            "[realtime] worker started: chunk={:.1}s, model='{}', language='{}', rate={}, channels={}, auto_paste={}, target={:?}",
+            CHUNK_SECONDS,
+            settings.active_model,
+            settings.language,
+            sample_rate,
+            channels,
+            settings.auto_paste,
+            target_focus
+        );
+
+        while active.load(Ordering::Relaxed) {
+            std::thread::sleep(Duration::from_millis(POLL_MS));
+
+            let raw_samples = {
+                let buf = samples.lock().unwrap();
+                let available = buf.len().saturating_sub(next_sample_index);
+                if available < raw_chunk_len {
+                    continue;
+                }
+                let end = buf.len();
+                let chunk = buf[next_sample_index..end].to_vec();
+                next_sample_index = end;
+                chunk
+            };
+
+            if sample_rms(&raw_samples) < MIN_RMS {
+                log::debug!("[realtime] skipping quiet chunk");
+                continue;
+            }
+
+            let samples_16k = match crate::audio::resample::resample_to_16k(
+                raw_samples,
+                sample_rate,
+                channels_usize,
+            ) {
+                Ok(samples) => samples,
+                Err(error) => {
+                    log::warn!("[realtime] resample failed: {}", error);
+                    emit_backend_error(&app, format!("Realtime resample error: {}", error));
+                    continue;
+                }
+            };
+
+            if !active.load(Ordering::Relaxed) {
+                break;
+            }
+
+            let duration_secs = samples_16k.len() as f32 / 16_000.0;
+            log::info!("[realtime] transcribing {:.1}s chunk", duration_secs);
+
+            match transcribe_realtime_chunk(
+                &app,
+                &samples_16k,
+                &settings.language,
+                settings.translate_to_english,
+                &settings.active_model,
+                &model_path,
+            ) {
+                Ok(text) if !text.trim().is_empty() => {
+                    if !active.load(Ordering::Relaxed) {
+                        break;
+                    }
+                    let text = text.trim().to_string();
+                    if !full_text.is_empty() {
+                        full_text.push(' ');
+                    }
+                    full_text.push_str(&text);
+                    output_seen.store(true, Ordering::Relaxed);
+                    log::info!("[realtime] partial: {:?}", text);
+                    emit_realtime_transcription(&app, &text, &full_text);
+
+                    if settings.auto_paste {
+                        if let Some(target) = target_focus.clone() {
+                            let committed_text = format!("{} ", text);
+                            log::info!(
+                                "[realtime] typing partial into target {:?}: {:?}",
+                                target,
+                                committed_text
+                            );
+                            if let Err(error) =
+                                crate::output::paste::type_text_into_target(target, &committed_text)
+                            {
+                                log::warn!("[realtime] live typing failed: {}", error);
+                                emit_backend_error(
+                                    &app,
+                                    format!("Realtime live typing error: {}", error),
+                                );
+                            }
+                        } else {
+                            log::warn!(
+                                "[realtime] auto_paste enabled but no target captured; start with the global hotkey from a focused text field"
+                            );
+                        }
+                    }
+                }
+                Ok(_) => {}
+                Err(error) => {
+                    if !active.load(Ordering::Relaxed) {
+                        break;
+                    }
+                    log::warn!("[realtime] transcription failed: {}", error);
+                    emit_backend_error(&app, format!("Realtime transcription error: {}", error));
+                }
+            }
+        }
+
+        log::info!("[realtime] worker stopped");
+    });
+}
+
+fn stop_realtime_worker(state: &AppState) {
+    if let Some(active) = state.realtime_worker_active.lock().unwrap().take() {
+        active.store(false, Ordering::Relaxed);
+    }
+}
+
+fn start_realtime_worker_if_recording(
+    app: &AppHandle,
+    state: &AppState,
+    settings: Settings,
+    start_at_current_audio: bool,
+) -> bool {
+    let recording_context = {
+        let recording = state.recording.lock().unwrap();
+        recording.as_ref().map(|handle| {
+            let start_sample_index = if start_at_current_audio {
+                handle.samples.lock().unwrap().len()
+            } else {
+                0
+            };
+            (
+                handle.samples.clone(),
+                handle.sample_rate,
+                handle.channels,
+                start_sample_index,
+            )
+        })
+    };
+
+    let Some((samples, sample_rate, channels, start_sample_index)) = recording_context else {
+        stop_realtime_worker(state);
+        return false;
+    };
+
+    {
+        let active_slot = state.realtime_worker_active.lock().unwrap();
+        if active_slot
+            .as_ref()
+            .is_some_and(|active| active.load(Ordering::Relaxed))
+        {
+            *state.realtime_used_in_recording.lock().unwrap() = true;
+            return true;
+        }
+    }
+
+    let realtime_active = Arc::new(AtomicBool::new(true));
+    {
+        let mut active_slot = state.realtime_worker_active.lock().unwrap();
+        if let Some(previous) = active_slot.take() {
+            previous.store(false, Ordering::Relaxed);
+        }
+        *active_slot = Some(realtime_active.clone());
+    }
+    *state.realtime_used_in_recording.lock().unwrap() = true;
+
+    let target_focus = state.target_focus.lock().unwrap().clone();
+    spawn_realtime_transcription_worker(
+        app.clone(),
+        realtime_active,
+        samples,
+        sample_rate,
+        channels,
+        settings,
+        target_focus,
+        start_sample_index,
+        state.realtime_output_seen.clone(),
+    );
+    true
+}
+
+fn sync_realtime_worker(
+    app: &AppHandle,
+    state: &AppState,
+    enabled: bool,
+    settings: Settings,
+    start_at_current_audio: bool,
+) -> bool {
+    if enabled {
+        start_realtime_worker_if_recording(app, state, settings, start_at_current_audio)
+    } else {
+        stop_realtime_worker(state);
+        false
+    }
 }
 
 #[tauri::command]
@@ -304,7 +584,14 @@ pub async fn start_recording(app: AppHandle, state: State<'_, AppState>) -> Resu
 
     let handle = crate::audio::capture::start_capture(settings.max_recording_seconds)?;
     let current_level = handle.current_level.clone();
+    let realtime_samples = handle.samples.clone();
+    let realtime_sample_rate = handle.sample_rate;
+    let realtime_channels = handle.channels;
+    let realtime_target_focus = state.target_focus.lock().unwrap().clone();
+    let target_captured = realtime_target_focus.is_some();
     *state.recording.lock().unwrap() = Some(handle);
+    *state.realtime_used_in_recording.lock().unwrap() = settings.realtime_transcription;
+    state.realtime_output_seen.store(false, Ordering::Relaxed);
 
     if let Some(win) = app.get_webview_window("overlay") {
         let _ = win.show();
@@ -333,15 +620,75 @@ pub async fn start_recording(app: AppHandle, state: State<'_, AppState>) -> Resu
         }
     });
 
-    app.emit("recording-started", ())
-        .map_err(|e| e.to_string())?;
+    if settings.realtime_transcription {
+        if let Some(active) = state.realtime_worker_active.lock().unwrap().take() {
+            active.store(false, Ordering::Relaxed);
+        }
+        let realtime_active = Arc::new(AtomicBool::new(true));
+        *state.realtime_worker_active.lock().unwrap() = Some(realtime_active.clone());
+        spawn_realtime_transcription_worker(
+            app.clone(),
+            realtime_active,
+            realtime_samples,
+            realtime_sample_rate,
+            realtime_channels,
+            settings.clone(),
+            realtime_target_focus,
+            0,
+            state.realtime_output_seen.clone(),
+        );
+    }
+
+    app.emit(
+        "recording-started",
+        serde_json::json!({
+            "realtime": settings.realtime_transcription,
+            "auto_paste": settings.auto_paste,
+            "target_captured": target_captured,
+        }),
+    )
+    .map_err(|e| e.to_string())?;
     Ok(())
+}
+
+#[tauri::command]
+pub async fn start_recording_from_settings(
+    app: AppHandle,
+    state: State<'_, AppState>,
+) -> Result<(), String> {
+    *state.target_focus.lock().unwrap() = None;
+    start_recording(app, state).await
+}
+
+#[tauri::command]
+pub async fn start_recording_from_settings_with_target_delay(
+    app: AppHandle,
+    state: State<'_, AppState>,
+) -> Result<(), String> {
+    if let Some(win) = app.get_webview_window("settings") {
+        let _ = win.hide();
+    }
+
+    tokio::time::sleep(Duration::from_millis(1600)).await;
+    let target = crate::output::paste::get_frontmost_target();
+    #[cfg(target_os = "macos")]
+    let target = target.filter(|pid| *pid != std::process::id() as i32);
+    log::info!(
+        "[settings] delayed start captured target_focus = {:?}",
+        target
+    );
+    *state.target_focus.lock().unwrap() = target;
+
+    start_recording(app, state).await
 }
 
 #[tauri::command]
 pub async fn stop_recording(app: AppHandle, state: State<'_, AppState>) -> Result<(), String> {
     // Stop the audio level emitter
     if let Some(active) = state.level_emitter_active.lock().unwrap().take() {
+        active.store(false, Ordering::Relaxed);
+    }
+    if let Some(active) = state.realtime_worker_active.lock().unwrap().take() {
         active.store(false, Ordering::Relaxed);
     }
 
@@ -360,19 +707,55 @@ pub async fn stop_recording(app: AppHandle, state: State<'_, AppState>) -> Resul
         }
     }
 
-    app.emit("recording-stopped", ())
-        .map_err(|e| e.to_string())?;
+    let used_realtime = {
+        let mut realtime_used = state.realtime_used_in_recording.lock().unwrap();
+        let used_realtime = *realtime_used;
+        *realtime_used = false;
+        used_realtime
+    };
+    let realtime_output_seen = state.realtime_output_seen.load(Ordering::Relaxed);
+    let skip_final_transcription = used_realtime && realtime_output_seen;
+    app.emit(
+        "recording-stopped",
+        serde_json::json!({
+            "finalizing": !skip_final_transcription,
+            "realtime": used_realtime,
+        }),
+    )
+    .map_err(|e| e.to_string())?;
+    emit_realtime_mode_updated(
+        &app,
+        state.settings.lock().unwrap().realtime_transcription,
+        false,
+    );
+
+    if skip_final_transcription {
+        log::info!("[realtime] skipping final batch transcription after realtime recording");
+        hide_overlay(&app);
+        let _ = app.emit(
+            "transcription-complete",
+            serde_json::json!({ "text": "", "realtime": true }),
+        );
+        return Ok(());
+    }
+
+    if used_realtime {
+        log::info!(
+            "[realtime] no realtime output was seen before stop; running final batch fallback"
+        );
+    }
 
     let samples_16k =
         crate::audio::resample::resample_to_16k(raw_samples, sample_rate, channels as usize)?;
     let (language, auto_paste, translate_to_english, target_focus, active_model, model_path) =
         transcription_inputs(&state);
+    let final_auto_paste = auto_paste && !state.settings.lock().unwrap().realtime_transcription;
 
     spawn_transcription(
         app,
         samples_16k,
         language,
-        auto_paste,
+        final_auto_paste,
         translate_to_english,
         target_focus,
         active_model,
@@ -429,15 +812,77 @@ pub async fn update_settings(
     settings: Settings,
     state: State<'_, AppState>,
 ) -> Result<(), String> {
-    let old_hotkey = state.settings.lock().unwrap().hotkey.clone();
+    let old_settings = state.settings.lock().unwrap().clone();
+    let old_hotkey = old_settings.hotkey.clone();
     let new_hotkey = settings.hotkey.clone();
 
-    settings.save()?;
-    *state.settings.lock().unwrap() = settings;
-
-    if old_hotkey != new_hotkey {
+    let hotkey_changed = old_hotkey != new_hotkey;
+    if hotkey_changed {
         crate::hotkey::manager::re_register_hotkey(&app, &old_hotkey, &new_hotkey)?;
     }
+
+    if let Err(error) = settings.save() {
+        if hotkey_changed {
+            let _ = crate::hotkey::manager::re_register_hotkey(&app, &new_hotkey, &old_hotkey);
+        }
+        return Err(error);
+    }
+    *state.settings.lock().unwrap() = settings.clone();
+
+    let mut realtime_active = state
+        .realtime_worker_active
+        .lock()
+        .unwrap()
+        .as_ref()
+        .is_some_and(|active| active.load(Ordering::Relaxed));
+
+    if old_settings.realtime_transcription != settings.realtime_transcription {
+        realtime_active = sync_realtime_worker(
+            &app,
+            &state,
+            settings.realtime_transcription,
+            settings.clone(),
+            true,
+        );
+        emit_realtime_mode_updated(&app, settings.realtime_transcription, realtime_active);
+    }
+
+    let _ = app.emit(
+        "settings-updated",
+        serde_json::json!({ "settings": settings, "realtime_active": realtime_active }),
+    );
+
+    Ok(())
+}
+
+#[tauri::command]
+pub async fn set_realtime_transcription(
+    app: AppHandle,
+    state: State<'_, AppState>,
+    enabled: bool,
+) -> Result<(), String> {
+    let mut settings = state.settings.lock().unwrap().clone();
+    if settings.realtime_transcription == enabled {
+        let active = state
+            .realtime_worker_active
+            .lock()
+            .unwrap()
+            .as_ref()
+            .is_some_and(|worker| worker.load(Ordering::Relaxed));
+        emit_realtime_mode_updated(&app, enabled, active);
+        return Ok(());
+    }
+
+    settings.realtime_transcription = enabled;
+    settings.save()?;
+    *state.settings.lock().unwrap() = settings.clone();
+
+    let realtime_active = sync_realtime_worker(&app, &state, enabled, settings.clone(), true);
+    emit_realtime_mode_updated(&app, enabled, realtime_active);
+    let _ = app.emit(
+        "settings-updated",
+        serde_json::json!({ "settings": settings, "realtime_active": realtime_active }),
+    );
 
     Ok(())
 }
@@ -670,5 +1115,11 @@ mod tests {
         assert!(validate_model_name("tiny/evil").is_err());
         assert!(validate_model_name("tiny\0evil").is_err());
         assert!(validate_model_name("").is_err());
+    }
+
+    #[test]
+    fn preview_text_keeps_unicode_boundaries() {
+        assert_eq!(preview_text("שלום עולם", 5), "שלום ...");
+        assert_eq!(preview_text("hello", 100), "hello");
     }
 }

--- a/src-tauri/src/config/settings.rs
+++ b/src-tauri/src/config/settings.rs
@@ -31,6 +31,8 @@ pub struct Settings {
     pub lower_volume_while_recording: bool,
     #[serde(default)]
     pub translate_to_english: bool,
+    #[serde(default)]
+    pub realtime_transcription: bool,
 }
 
 fn default_true() -> bool {
@@ -50,6 +52,7 @@ impl Default for Settings {
             overlay_position: OverlayPosition::TopCenter,
             lower_volume_while_recording: true,
             translate_to_english: false,
+            realtime_transcription: false,
         }
     }
 }
@@ -97,6 +100,7 @@ mod tests {
         assert!(!s.launch_at_login);
         assert_eq!(s.overlay_position, OverlayPosition::TopCenter);
         assert!(s.lower_volume_while_recording);
+        assert!(!s.realtime_transcription);
     }
 
     #[test]
@@ -122,6 +126,7 @@ mod tests {
         }"#;
         let settings: Settings = serde_json::from_str(json).unwrap();
         assert!(settings.lower_volume_while_recording);
+        assert!(!settings.realtime_transcription);
     }
 
     #[test]
@@ -136,6 +141,7 @@ mod tests {
             "launch_at_login": false,
             "overlay_position": "top_center",
             "lower_volume_while_recording": true,
+            "realtime_transcription": false,
             "unknown_future_field": 42,
             "another_unknown": "hello"
         }"#;

--- a/src-tauri/src/hotkey/manager.rs
+++ b/src-tauri/src/hotkey/manager.rs
@@ -58,13 +58,10 @@ pub fn re_register_hotkey(
     new_hotkey: &str,
 ) -> Result<(), String> {
     let shortcuts = app.global_shortcut();
+    let old_was_registered = shortcuts.is_registered(old_hotkey);
 
-    if shortcuts.is_registered(old_hotkey) {
-        shortcuts
-            .unregister(old_hotkey)
-            .map_err(|e| e.to_string())?;
-    }
-
+    // Register the new shortcut before touching the old one so a malformed
+    // autosaved hotkey cannot leave the app with no working shortcut.
     let handle = app.clone();
     shortcuts
         .on_shortcut(new_hotkey, move |_app, _shortcut, event| {
@@ -98,5 +95,14 @@ pub fn re_register_hotkey(
                 }
             }
         })
-        .map_err(|e| e.to_string())
+        .map_err(|e| e.to_string())?;
+
+    if old_was_registered {
+        if let Err(error) = shortcuts.unregister(old_hotkey) {
+            let _ = shortcuts.unregister(new_hotkey);
+            return Err(error.to_string());
+        }
+    }
+
+    Ok(())
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -16,10 +16,14 @@ use tauri::{Emitter, Manager};
 pub struct AppState {
     pub settings: Mutex<Settings>,
     pub whisper_ctx: Mutex<Option<whisper_rs::WhisperContext>>,
+    pub transcription_lock: Mutex<()>,
     pub recording: Mutex<Option<audio::capture::RecordingHandle>>,
     pub target_focus: Mutex<Option<FocusTarget>>,
     pub original_volume: Mutex<Option<f32>>,
     pub level_emitter_active: Mutex<Option<std::sync::Arc<std::sync::atomic::AtomicBool>>>,
+    pub realtime_worker_active: Mutex<Option<std::sync::Arc<std::sync::atomic::AtomicBool>>>,
+    pub realtime_used_in_recording: Mutex<bool>,
+    pub realtime_output_seen: std::sync::Arc<std::sync::atomic::AtomicBool>,
 }
 
 /// macOS: Checks if the app has Accessibility permission.
@@ -335,9 +339,20 @@ fn init_logging() {
 pub fn run() {
     init_logging();
     log::info!("=== Careless Whisper starting ===");
-    log::info!("[system] version={}, os={}, arch={}", env!("CARGO_PKG_VERSION"), std::env::consts::OS, std::env::consts::ARCH);
+    log::info!(
+        "[system] version={}, os={}, arch={}",
+        env!("CARGO_PKG_VERSION"),
+        std::env::consts::OS,
+        std::env::consts::ARCH
+    );
     let settings = Settings::load();
-    log::info!("[settings] model='{}', language='{}', hotkey='{}', mode={:?}", settings.active_model, settings.language, settings.hotkey, settings.recording_mode);
+    log::info!(
+        "[settings] model='{}', language='{}', hotkey='{}', mode={:?}",
+        settings.active_model,
+        settings.language,
+        settings.hotkey,
+        settings.recording_mode
+    );
 
     tauri::Builder::default()
         .plugin(tauri_plugin_opener::init())
@@ -350,10 +365,14 @@ pub fn run() {
         .manage(AppState {
             settings: Mutex::new(settings),
             whisper_ctx: Mutex::new(None),
+            transcription_lock: Mutex::new(()),
             recording: Mutex::new(None),
             target_focus: Mutex::new(None),
             original_volume: Mutex::new(None),
             level_emitter_active: Mutex::new(None),
+            realtime_worker_active: Mutex::new(None),
+            realtime_used_in_recording: Mutex::new(false),
+            realtime_output_seen: std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false)),
         })
         .setup(|app| {
             #[cfg(target_os = "macos")]
@@ -426,10 +445,13 @@ pub fn run() {
         })
         .invoke_handler(tauri::generate_handler![
             start_recording,
+            start_recording_from_settings,
+            start_recording_from_settings_with_target_delay,
             stop_recording,
             transcribe_audio_file,
             get_settings,
             update_settings,
+            set_realtime_transcription,
             list_models,
             download_model,
             delete_model,

--- a/src-tauri/src/output/clipboard.rs
+++ b/src-tauri/src/output/clipboard.rs
@@ -29,7 +29,5 @@ fn try_copy(text: &str) -> Result<(), String> {
 }
 
 pub fn read_clipboard() -> Option<String> {
-    Clipboard::new()
-        .ok()
-        .and_then(|mut cb| cb.get_text().ok())
+    Clipboard::new().ok().and_then(|mut cb| cb.get_text().ok())
 }

--- a/src-tauri/src/output/paste.rs
+++ b/src-tauri/src/output/paste.rs
@@ -32,11 +32,27 @@ pub fn get_frontmost_target() -> Option<FocusTarget> {
     }
 }
 
+#[cfg(target_os = "macos")]
+fn activate_target_app(target: FocusTarget) {
+    use objc2::msg_send;
+    use objc2::runtime::AnyClass;
+
+    unsafe {
+        if let Some(cls) = AnyClass::get(c"NSRunningApplication") {
+            let app: *mut objc2::runtime::AnyObject =
+                msg_send![cls, runningApplicationWithProcessIdentifier: target];
+            if !app.is_null() {
+                let _: bool = msg_send![app, activateWithOptions: 2u64];
+            }
+        }
+    }
+
+    std::thread::sleep(std::time::Duration::from_millis(100));
+}
+
 /// Activates the target app and simulates Cmd+V via CoreGraphics CGEventPostToPid.
 #[cfg(target_os = "macos")]
 pub fn paste_into_target(target: FocusTarget) -> Result<(), String> {
-    use objc2::msg_send;
-    use objc2::runtime::AnyClass;
     use std::os::raw::c_void;
 
     #[link(name = "CoreGraphics", kind = "framework")]
@@ -58,18 +74,7 @@ pub fn paste_into_target(target: FocusTarget) -> Result<(), String> {
     const KCG_EVENT_FLAG_MASK_COMMAND: u64 = 1 << 20;
     const KVK_ANSI_V: u16 = 9;
 
-    // Re-activate the target app so it's frontmost and ready to receive input.
-    unsafe {
-        if let Some(cls) = AnyClass::get(c"NSRunningApplication") {
-            let app: *mut objc2::runtime::AnyObject =
-                msg_send![cls, runningApplicationWithProcessIdentifier: target];
-            if !app.is_null() {
-                let _: bool = msg_send![app, activateWithOptions: 2u64];
-            }
-        }
-    }
-
-    std::thread::sleep(std::time::Duration::from_millis(100));
+    activate_target_app(target);
 
     // Send Cmd+V directly to the target PID
     unsafe {
@@ -93,6 +98,60 @@ pub fn paste_into_target(target: FocusTarget) -> Result<(), String> {
     }
 
     std::thread::sleep(std::time::Duration::from_millis(50));
+    Ok(())
+}
+
+#[cfg(target_os = "macos")]
+pub fn type_text_into_target(target: FocusTarget, text: &str) -> Result<(), String> {
+    use std::os::raw::c_void;
+
+    #[link(name = "CoreGraphics", kind = "framework")]
+    extern "C" {
+        fn CGEventCreateKeyboardEvent(
+            source: *const c_void,
+            virtual_key: u16,
+            key_down: bool,
+        ) -> *mut c_void;
+        fn CGEventKeyboardSetUnicodeString(
+            event: *mut c_void,
+            string_length: usize,
+            unicode_string: *const u16,
+        );
+        fn CGEventPostToPid(pid: i32, event: *mut c_void);
+    }
+
+    #[link(name = "CoreFoundation", kind = "framework")]
+    extern "C" {
+        fn CFRelease(cf: *mut c_void);
+    }
+
+    if text.is_empty() {
+        return Ok(());
+    }
+
+    activate_target_app(target);
+
+    let utf16: Vec<u16> = text.encode_utf16().collect();
+    for chunk in utf16.chunks(32) {
+        unsafe {
+            let key_down = CGEventCreateKeyboardEvent(std::ptr::null(), 0, true);
+            if key_down.is_null() {
+                return Err("Failed to create Unicode key-down event".into());
+            }
+            CGEventKeyboardSetUnicodeString(key_down, chunk.len(), chunk.as_ptr());
+            CGEventPostToPid(target, key_down);
+            CFRelease(key_down);
+
+            let key_up = CGEventCreateKeyboardEvent(std::ptr::null(), 0, false);
+            if key_up.is_null() {
+                return Err("Failed to create Unicode key-up event".into());
+            }
+            CGEventPostToPid(target, key_up);
+            CFRelease(key_up);
+        }
+        std::thread::sleep(std::time::Duration::from_millis(3));
+    }
+
     Ok(())
 }
 
@@ -139,7 +198,10 @@ pub fn paste_into_target(target: FocusTarget) -> Result<(), String> {
 
         log::info!(
             "[paste] our_thread={}, fg_thread={}, target_thread={}, target_hwnd={}",
-            our_thread, fg_thread, target_thread, target
+            our_thread,
+            fg_thread,
+            target_thread,
+            target
         );
 
         // Attach our thread to the foreground window's thread so we gain
@@ -149,11 +211,12 @@ pub fn paste_into_target(target: FocusTarget) -> Result<(), String> {
         } else {
             false
         };
-        let attached_target = if our_thread != target_thread && target_thread != fg_thread && target_thread != 0 {
-            AttachThreadInput(our_thread, target_thread, true).0 != 0
-        } else {
-            false
-        };
+        let attached_target =
+            if our_thread != target_thread && target_thread != fg_thread && target_thread != 0 {
+                AttachThreadInput(our_thread, target_thread, true).0 != 0
+            } else {
+                false
+            };
 
         // AttachThreadInput above gives us permission to call SetForegroundWindow
         // without the old Alt-key hack (which activated menu bars in apps like Notepad).
@@ -215,6 +278,12 @@ pub fn paste_into_target(target: FocusTarget) -> Result<(), String> {
 
     std::thread::sleep(std::time::Duration::from_millis(50));
     Ok(())
+}
+
+#[cfg(target_os = "windows")]
+pub fn type_text_into_target(target: FocusTarget, text: &str) -> Result<(), String> {
+    crate::output::clipboard::copy_to_clipboard(text)?;
+    paste_into_target(target)
 }
 
 // ── Linux implementation ────────────────────────────────────────────────────
@@ -302,6 +371,12 @@ fn paste_x11(window_id: &str) -> Result<(), String> {
 
     std::thread::sleep(std::time::Duration::from_millis(50));
     Ok(())
+}
+
+#[cfg(target_os = "linux")]
+pub fn type_text_into_target(target: FocusTarget, text: &str) -> Result<(), String> {
+    crate::output::clipboard::copy_to_clipboard(text)?;
+    paste_into_target(target)
 }
 
 #[cfg(target_os = "linux")]

--- a/src-tauri/src/transcribe/whisper.rs
+++ b/src-tauri/src/transcribe/whisper.rs
@@ -23,7 +23,12 @@ pub fn load_model(path: &Path) -> Result<WhisperContext, String> {
     })
 }
 
-pub fn transcribe(ctx: &WhisperContext, samples: &[f32], language: &str, translate: bool) -> Result<String, String> {
+pub fn transcribe(
+    ctx: &WhisperContext,
+    samples: &[f32],
+    language: &str,
+    translate: bool,
+) -> Result<String, String> {
     let mut state = ctx.create_state().map_err(|e| format!("{:?}", e))?;
 
     let mut params = FullParams::new(SamplingStrategy::Greedy { best_of: 1 });
@@ -42,10 +47,17 @@ pub fn transcribe(ctx: &WhisperContext, samples: &[f32], language: &str, transla
     let single_segment = duration_secs < 30.0;
     params.set_single_segment(single_segment);
 
-    let lang_label = if language == "auto" || language.is_empty() { "auto" } else { language };
+    let lang_label = if language == "auto" || language.is_empty() {
+        "auto"
+    } else {
+        language
+    };
     log::info!(
         "[whisper] transcribing {:.1}s audio | threads={} | language={} | single_segment={}",
-        duration_secs, n_threads, lang_label, single_segment
+        duration_secs,
+        n_threads,
+        lang_label,
+        single_segment
     );
 
     // "auto" → empty string triggers whisper.cpp auto-detect

--- a/src-tauri/src/tray.rs
+++ b/src-tauri/src/tray.rs
@@ -3,7 +3,7 @@
 
 use tauri::{
     menu::{CheckMenuItem, IsMenuItem, Menu, MenuItem, PredefinedMenuItem, Submenu},
-    tray::TrayIconBuilder,
+    tray::{MouseButton, MouseButtonState, TrayIconBuilder, TrayIconEvent},
     AppHandle, Emitter, Manager, Runtime, WindowEvent,
 };
 
@@ -53,7 +53,8 @@ fn build_tray_menu<R: Runtime>(app: &AppHandle<R>, current_lang: &str) -> tauri:
         .iter()
         .map(|item| item as &dyn IsMenuItem<R>)
         .collect();
-    let language_submenu = Submenu::with_id_and_items(app, "language", "Language", true, &lang_refs)?;
+    let language_submenu =
+        Submenu::with_id_and_items(app, "language", "Language", true, &lang_refs)?;
 
     Menu::with_items(app, &[&settings, &language_submenu, &sep, &quit])
 }
@@ -84,10 +85,14 @@ fn change_language<R: Runtime>(app: &AppHandle<R>, code: &str) {
         Err(e) => log::warn!("[tray] failed to rebuild menu: {}", e),
     }
 
-    let _ = app.emit(
-        "settings-updated",
-        serde_json::json!({ "language": code }),
-    );
+    let _ = app.emit("settings-updated", serde_json::json!({ "language": code }));
+}
+
+fn show_settings_window<R: Runtime>(app: &AppHandle<R>) {
+    if let Some(window) = app.get_webview_window("settings") {
+        let _ = window.show();
+        let _ = window.set_focus();
+    }
 }
 
 pub fn setup_tray<R: Runtime>(app: &AppHandle<R>) -> tauri::Result<()> {
@@ -123,6 +128,17 @@ pub fn setup_tray<R: Runtime>(app: &AppHandle<R>) -> tauri::Result<()> {
         .icon(tray_icon)
         .icon_as_template(true)
         .menu(&menu)
+        .show_menu_on_left_click(false)
+        .on_tray_icon_event(|tray, event| {
+            if let TrayIconEvent::Click {
+                button: MouseButton::Left,
+                button_state: MouseButtonState::Down,
+                ..
+            } = event
+            {
+                show_settings_window(tray.app_handle());
+            }
+        })
         .on_menu_event(|app, event| {
             let id = event.id.as_ref();
             if let Some(code) = id.strip_prefix("lang_") {
@@ -131,10 +147,7 @@ pub fn setup_tray<R: Runtime>(app: &AppHandle<R>) -> tauri::Result<()> {
             }
             match id {
                 "settings" => {
-                    if let Some(window) = app.get_webview_window("settings") {
-                        let _ = window.show();
-                        let _ = window.set_focus();
-                    }
+                    show_settings_window(app);
                 }
                 "quit" => {
                     app.exit(0);

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -4,9 +4,9 @@
   "version": "0.5.6",
   "identifier": "com.whispertap.careless-whisper",
   "build": {
-    "beforeDevCommand": "pnpm dev",
+    "beforeDevCommand": "corepack pnpm dev",
     "devUrl": "http://localhost:1420",
-    "beforeBuildCommand": "pnpm build",
+    "beforeBuildCommand": "corepack pnpm build",
     "frontendDist": "../dist"
   },
   "app": {
@@ -23,11 +23,12 @@
       {
         "label": "overlay",
         "title": "",
-        "width": 320,
-        "height": 80,
+        "width": 360,
+        "height": 120,
         "visible": false,
         "decorations": false,
         "alwaysOnTop": true,
+        "visibleOnAllWorkspaces": true,
         "skipTaskbar": true,
         "resizable": false,
         "transparent": true,

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -37,7 +37,7 @@ function SettingsWindow() {
     }
 
     if (event.type === "transcription-complete") {
-      setToastMessage("Transcription copied to clipboard");
+      setToastMessage("Transcription complete");
       setToastVisible(true);
     }
   });

--- a/src/components/Overlay.tsx
+++ b/src/components/Overlay.tsx
@@ -1,5 +1,7 @@
-import { useState, useEffect, useRef } from "react";
+import { useState, useEffect, useRef, type PointerEvent } from "react";
+import { invoke } from "@tauri-apps/api/core";
 import { listen } from "@tauri-apps/api/event";
+import { LogicalSize, getCurrentWindow } from "@tauri-apps/api/window";
 import { useTauriEvents } from "../hooks/useTauriEvents";
 
 type OverlayState = "idle" | "recording" | "transcribing" | "error";
@@ -8,12 +10,24 @@ type OverlayState = "idle" | "recording" | "transcribing" | "error";
 const BAR_WEIGHTS = [0.35, 0.65, 1.0, 0.65, 0.35];
 const MIN_HEIGHT = 3;
 const MAX_HEIGHT = 16;
+const OVERLAY_WIDTH = 360;
+const OVERLAY_BASE_HEIGHT = 120;
+const OVERLAY_MAX_HEIGHT = 280;
 
 export function Overlay() {
   const [state, setState] = useState<OverlayState>("idle");
   const [errorMsg, setErrorMsg] = useState("");
+  const [partialText, setPartialText] = useState("");
+  const [realtimeActive, setRealtimeActive] = useState(false);
+  const [realtimeArmed, setRealtimeArmed] = useState(false);
+  const [autoPaste, setAutoPaste] = useState(false);
+  const [targetCaptured, setTargetCaptured] = useState(false);
+  const [realtimeChanging, setRealtimeChanging] = useState(false);
   const [barHeights, setBarHeights] = useState<number[] | null>(null);
   const [elapsed, setElapsed] = useState(0);
+  const rootRef = useRef<HTMLDivElement | null>(null);
+  const partialRef = useRef<HTMLDivElement | null>(null);
+  const lastWindowHeight = useRef(OVERLAY_BASE_HEIGHT);
   const smoothedLevel = useRef(0);
   const timerRef = useRef<ReturnType<typeof setInterval> | null>(null);
 
@@ -21,17 +35,44 @@ export function Overlay() {
     if (event.type === "recording-started") {
       setState("recording");
       setElapsed(0);
+      setPartialText("");
+      setRealtimeActive(event.realtime);
+      setRealtimeArmed(event.realtime);
+      setAutoPaste(event.autoPaste);
+      setTargetCaptured(event.targetCaptured);
     } else if (event.type === "recording-stopped") {
-      setState("transcribing");
+      setState(event.finalizing ? "transcribing" : "idle");
       setBarHeights(null);
+      if (!event.finalizing) {
+        setPartialText("");
+        setRealtimeActive(false);
+      }
+    } else if (event.type === "realtime-transcription") {
+      setPartialText(event.fullText);
+    } else if (event.type === "realtime-mode-updated") {
+      setRealtimeArmed(event.armed);
+      setRealtimeActive(event.active);
+      setRealtimeChanging(false);
+      if (!event.active) {
+        setPartialText("");
+      }
     } else if (event.type === "transcription-complete") {
       setState("idle");
+      setPartialText("");
+      setRealtimeActive(false);
     } else if (event.type === "transcription-error") {
       setErrorMsg(event.message);
+      setRealtimeActive(false);
       setState("error");
       setTimeout(() => setState("idle"), 3000);
     }
   });
+
+  useEffect(() => {
+    void invoke<{ realtime_transcription: boolean }>("get_settings")
+      .then((settings) => setRealtimeArmed(settings.realtime_transcription))
+      .catch(() => {});
+  }, []);
 
   useEffect(() => {
     if (state === "recording") {
@@ -50,6 +91,29 @@ export function Overlay() {
 
   const formatTime = (s: number) =>
     `${String(Math.floor(s / 60)).padStart(2, "0")}:${String(s % 60).padStart(2, "0")}`;
+
+  const startOverlayDrag = (event: PointerEvent<HTMLDivElement>) => {
+    if (event.button !== 0) return;
+    const target = event.target as HTMLElement | null;
+    if (target?.closest("button")) return;
+    if (!target?.closest(".overlay-pill")) return;
+    void getCurrentWindow().startDragging().catch(() => {});
+  };
+
+  const toggleRealtimeMode = async () => {
+    const nextMode = !realtimeArmed;
+    setRealtimeChanging(true);
+    setRealtimeArmed(nextMode);
+    try {
+      await invoke("set_realtime_transcription", { enabled: nextMode });
+    } catch (error) {
+      setRealtimeArmed(!nextMode);
+      setRealtimeChanging(false);
+      setErrorMsg(String(error));
+      setState("error");
+      setTimeout(() => setState("recording"), 3000);
+    }
+  };
 
   useEffect(() => {
     let cancelled = false;
@@ -81,23 +145,106 @@ export function Overlay() {
     };
   }, []);
 
+  useEffect(() => {
+    const partial = partialRef.current;
+    if (partial) {
+      partial.scrollTop = partial.scrollHeight;
+    }
+  }, [partialText]);
+
+  useEffect(() => {
+    if (state === "idle") {
+      if (lastWindowHeight.current !== OVERLAY_BASE_HEIGHT) {
+        lastWindowHeight.current = OVERLAY_BASE_HEIGHT;
+        void getCurrentWindow()
+          .setSize(new LogicalSize(OVERLAY_WIDTH, OVERLAY_BASE_HEIGHT))
+          .catch(() => {});
+      }
+      return;
+    }
+
+    const root = rootRef.current;
+    const pill = root?.querySelector<HTMLElement>(".overlay-pill");
+    if (!pill) return;
+
+    const resizeWindow = () => {
+      const nextHeight = Math.min(
+        OVERLAY_MAX_HEIGHT,
+        Math.max(OVERLAY_BASE_HEIGHT, Math.ceil(pill.scrollHeight) + 16)
+      );
+      if (Math.abs(nextHeight - lastWindowHeight.current) < 2) {
+        return;
+      }
+      lastWindowHeight.current = nextHeight;
+      void getCurrentWindow()
+        .setSize(new LogicalSize(OVERLAY_WIDTH, nextHeight))
+        .catch(() => {});
+    };
+
+    resizeWindow();
+    const observer = new ResizeObserver(resizeWindow);
+    observer.observe(pill);
+    return () => observer.disconnect();
+  }, [state, realtimeActive, partialText]);
+
   if (state === "idle") return null;
 
   return (
-    <div className="overlay-root">
+    <div className="overlay-root" ref={rootRef} onPointerDown={startOverlayDrag}>
       {state === "recording" && (
-        <div className="overlay-pill overlay-recording">
-          <span className="recording-dot" />
-          <div className="waveform">
-            {BAR_WEIGHTS.map((_, i) => (
-              <span
-                key={i}
-                className="waveform-bar"
-                style={barHeights ? { height: `${barHeights[i]}px` } : {}}
-              />
-            ))}
+        <div
+          className={`overlay-pill overlay-recording ${
+            realtimeActive ? "overlay-recording-live" : ""
+          }`}
+        >
+          <div className="overlay-row">
+            <span className="recording-dot" />
+            <div className="waveform">
+              {BAR_WEIGHTS.map((_, i) => (
+                <span
+                  key={i}
+                  className="waveform-bar"
+                  style={barHeights ? { height: `${barHeights[i]}px` } : {}}
+                />
+              ))}
+            </div>
+            <span className="overlay-timer">{formatTime(elapsed)}</span>
+            <span
+              className={`overlay-mode-badge ${
+                realtimeActive ? "overlay-mode-badge-live" : "overlay-mode-badge-disabled"
+              }`}
+            >
+              {realtimeActive ? "Realtime" : realtimeArmed ? "Armed" : "Batch"}
+            </span>
+            <span
+              className={`overlay-target-badge ${
+                autoPaste && targetCaptured
+                  ? "overlay-target-badge-ready"
+                  : "overlay-target-badge-muted"
+              }`}
+            >
+              {autoPaste ? (targetCaptured ? "Typing" : "No target") : "Paste off"}
+            </span>
+            <button
+              className="overlay-mode-toggle"
+              onClick={(event) => {
+                event.stopPropagation();
+                void toggleRealtimeMode();
+              }}
+              disabled={realtimeChanging}
+              title={realtimeArmed ? "Disable realtime transcription" : "Arm realtime transcription"}
+            >
+              {realtimeArmed ? "Disable" : "Arm"}
+            </button>
           </div>
-          <span className="overlay-timer">{formatTime(elapsed)}</span>
+          {realtimeActive && (
+            <div
+              ref={partialRef}
+              className={`overlay-partial ${partialText ? "" : "overlay-partial-pending"}`}
+            >
+              {partialText || "Listening for live transcription..."}
+            </div>
+          )}
         </div>
       )}
       {state === "transcribing" && (

--- a/src/components/Settings.tsx
+++ b/src/components/Settings.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { invoke } from "@tauri-apps/api/core";
 import { open } from "@tauri-apps/plugin-dialog";
 import { openUrl } from "@tauri-apps/plugin-opener";
@@ -16,6 +16,7 @@ interface Settings {
   overlay_position: "top_center" | "bottom_center" | "top_left" | "top_right";
   lower_volume_while_recording: boolean;
   translate_to_english: boolean;
+  realtime_transcription: boolean;
 }
 
 const AUDIO_FILE_FILTERS = [
@@ -24,6 +25,8 @@ const AUDIO_FILE_FILTERS = [
     extensions: ["mp3", "wav", "m4a", "mp4", "aac", "flac", "ogg", "oga"],
   },
 ];
+
+const AUTOSAVE_DEBOUNCE_MS = 600;
 
 export function Settings() {
   const [settings, setSettings] = useState<Settings | null>(null);
@@ -36,6 +39,28 @@ export function Settings() {
   const [appVersion, setAppVersion] = useState("");
   const [selectedAudioPath, setSelectedAudioPath] = useState<string | null>(null);
   const [transcribingFile, setTranscribingFile] = useState(false);
+  const [recording, setRecording] = useState(false);
+  const [finalizingRecording, setFinalizingRecording] = useState(false);
+  const settingsRef = useRef<Settings | null>(null);
+  const saveTimerRef = useRef<number | null>(null);
+  const savedTimerRef = useRef<number | null>(null);
+  const saveRevisionRef = useRef(0);
+  const inFlightSavesRef = useRef(0);
+
+  useEffect(() => {
+    settingsRef.current = settings;
+  }, [settings]);
+
+  useEffect(() => {
+    return () => {
+      if (saveTimerRef.current !== null) {
+        window.clearTimeout(saveTimerRef.current);
+      }
+      if (savedTimerRef.current !== null) {
+        window.clearTimeout(savedTimerRef.current);
+      }
+    };
+  }, []);
 
   useEffect(() => {
     void getVersion().then(setAppVersion).catch(() => {});
@@ -51,18 +76,46 @@ export function Settings() {
     const unlistenTranscriptionError = listen<{ message: string }>("transcription-error", (e) => {
       setLastError(e.payload.message);
       setTranscribingFile(false);
+      setFinalizingRecording(false);
     });
     const unlistenComplete = listen<{ text: string }>("transcription-complete", () => {
       setTranscribingFile(false);
+      setFinalizingRecording(false);
     });
-    const unlistenSettingsUpdated = listen("settings-updated", () => {
-      void invoke<Settings>("get_settings").then(setSettings);
+    const unlistenRecordingStarted = listen("recording-started", () => {
+      setRecording(true);
+      setFinalizingRecording(false);
+    });
+    const unlistenRecordingStopped = listen<{ finalizing?: boolean }>("recording-stopped", (e) => {
+      setRecording(false);
+      setFinalizingRecording(e.payload?.finalizing ?? true);
+    });
+    const unlistenSettingsUpdated = listen<{ settings?: Settings }>("settings-updated", (e) => {
+      if (saveTimerRef.current !== null || inFlightSavesRef.current > 0) {
+        return;
+      }
+
+      if (e.payload?.settings) {
+        settingsRef.current = e.payload.settings;
+        setSettings(e.payload.settings);
+        return;
+      }
+
+      void invoke<Settings>("get_settings").then((nextSettings) => {
+        if (saveTimerRef.current !== null || inFlightSavesRef.current > 0) {
+          return;
+        }
+        settingsRef.current = nextSettings;
+        setSettings(nextSettings);
+      });
     });
 
     return () => {
       void unlistenError.then((fn) => fn());
       void unlistenTranscriptionError.then((fn) => fn());
       void unlistenComplete.then((fn) => fn());
+      void unlistenRecordingStarted.then((fn) => fn());
+      void unlistenRecordingStopped.then((fn) => fn());
       void unlistenSettingsUpdated.then((fn) => fn());
     };
   }, []);
@@ -89,16 +142,80 @@ export function Settings() {
     return () => window.removeEventListener("focus", onFocus);
   }, []);
 
-  const save = async () => {
-    if (!settings) return;
+  const showSavedState = () => {
+    setSaved(true);
+    if (savedTimerRef.current !== null) {
+      window.clearTimeout(savedTimerRef.current);
+    }
+    savedTimerRef.current = window.setTimeout(() => {
+      setSaved(false);
+      savedTimerRef.current = null;
+    }, 1800);
+  };
+
+  const saveSettings = async (nextSettings: Settings, revision: number) => {
+    inFlightSavesRef.current += 1;
     setSaving(true);
     try {
-      await invoke("update_settings", { settings });
-      setSaved(true);
-      window.setTimeout(() => setSaved(false), 2000);
+      await invoke("update_settings", { settings: nextSettings });
+      if (revision === saveRevisionRef.current) {
+        showSavedState();
+      }
     } finally {
-      setSaving(false);
+      inFlightSavesRef.current = Math.max(0, inFlightSavesRef.current - 1);
+      if (inFlightSavesRef.current === 0) {
+        setSaving(false);
+      }
     }
+  };
+
+  const persistSettings = (nextSettings: Settings, previousSettings: Settings, revision: number) => {
+    void saveSettings(nextSettings, revision).catch((error) => {
+      if (revision !== saveRevisionRef.current) {
+        return;
+      }
+      settingsRef.current = previousSettings;
+      setSettings(previousSettings);
+      setLastError(`Failed to save settings: ${String(error)}`);
+    });
+  };
+
+  const updateSettings = (
+    patch: Partial<Settings> | ((current: Settings) => Settings),
+    options: { debounce?: boolean } = {}
+  ) => {
+    const previousSettings = settingsRef.current;
+    if (!previousSettings) return;
+
+    const nextSettings =
+      typeof patch === "function" ? patch(previousSettings) : { ...previousSettings, ...patch };
+    const revision = saveRevisionRef.current + 1;
+    saveRevisionRef.current = revision;
+
+    if (saveTimerRef.current !== null) {
+      window.clearTimeout(saveTimerRef.current);
+      saveTimerRef.current = null;
+    }
+
+    settingsRef.current = nextSettings;
+    setSettings(nextSettings);
+    setLastError(null);
+    setSaved(false);
+
+    const runSave = () => {
+      saveTimerRef.current = null;
+      persistSettings(nextSettings, previousSettings, revision);
+    };
+
+    if (options.debounce) {
+      saveTimerRef.current = window.setTimeout(runSave, AUTOSAVE_DEBOUNCE_MS);
+    } else {
+      runSave();
+    }
+  };
+
+  const setRealtimeMode = (enabled: boolean) => {
+    updateSettings({ realtime_transcription: enabled });
   };
 
   const chooseAudioFile = async () => {
@@ -128,6 +245,21 @@ export function Settings() {
     }
   };
 
+  const toggleRecording = async () => {
+    setLastError(null);
+    try {
+      if (recording) {
+        await invoke("stop_recording");
+      } else {
+        await invoke("start_recording_from_settings_with_target_delay");
+      }
+    } catch (error) {
+      setRecording(false);
+      setFinalizingRecording(false);
+      setLastError(String(error));
+    }
+  };
+
   if (!settings) return <div>Loading…</div>;
 
   return (
@@ -136,9 +268,11 @@ export function Settings() {
         <h2 style={{ margin: 0, fontSize: 18, fontWeight: 700 }}>
           Careless Whisper
         </h2>
-        {appVersion && (
-          <span style={{ fontSize: 12, opacity: 0.5 }}>v{appVersion}</span>
-        )}
+        <div className="settings-header-meta">
+          {saving && <span className="settings-save-status">Saving...</span>}
+          {!saving && saved && <span className="settings-save-status settings-save-status-saved">Saved</span>}
+          {appVersion && <span>v{appVersion}</span>}
+        </div>
       </div>
 
       {accessibilityGranted === false && (
@@ -188,6 +322,37 @@ export function Settings() {
         </div>
       )}
 
+      <div className="settings-section recording-control">
+        <div>
+          <label className="settings-label">Recording</label>
+          <div className="recording-helper">
+            The hotkey starts immediately. The button hides Settings first; focus the target field when it closes.
+          </div>
+          <div className="recording-mode-row">
+            <button
+              type="button"
+              className={`mode-pill ${
+                settings.realtime_transcription ? "mode-pill-armed" : "mode-pill-disabled"
+              }`}
+              onClick={() => setRealtimeMode(!settings.realtime_transcription)}
+            >
+              {settings.realtime_transcription ? "Realtime armed" : "Realtime disabled"}
+            </button>
+            {settings.auto_paste && (
+              <span className="mode-pill mode-pill-armed">Auto-paste on</span>
+            )}
+          </div>
+        </div>
+        <button
+          className={recording ? "btn-danger" : "btn-primary"}
+          onClick={() => void toggleRecording()}
+          disabled={finalizingRecording}
+          title="Starts after Settings hides; focus the destination field when it closes."
+        >
+          {recording ? "Stop Recording" : finalizingRecording ? "Transcribing..." : "Start Recording"}
+        </button>
+      </div>
+
       <div className="settings-section">
         <label className="settings-label">Transcribe Audio File</label>
         <div style={{ display: "flex", gap: 8, alignItems: "center", flexWrap: "wrap" }}>
@@ -213,7 +378,7 @@ export function Settings() {
           className="settings-input"
           value={settings.hotkey}
           onChange={(e) =>
-            setSettings({ ...settings, hotkey: e.target.value })
+            updateSettings({ hotkey: e.target.value }, { debounce: true })
           }
           placeholder="e.g. CmdOrCtrl+Shift+Space"
         />
@@ -225,8 +390,7 @@ export function Settings() {
           className="settings-select"
           value={settings.recording_mode}
           onChange={(e) =>
-            setSettings({
-              ...settings,
+            updateSettings({
               recording_mode: e.target.value as Settings["recording_mode"],
             })
           }
@@ -242,7 +406,7 @@ export function Settings() {
           className="settings-select"
           value={settings.language}
           onChange={(e) =>
-            setSettings({ ...settings, language: e.target.value })
+            updateSettings({ language: e.target.value })
           }
         >
           <option value="auto">Auto-detect</option>
@@ -277,8 +441,7 @@ export function Settings() {
           className="settings-select"
           value={settings.overlay_position}
           onChange={(e) =>
-            setSettings({
-              ...settings,
+            updateSettings({
               overlay_position: e.target.value as Settings["overlay_position"],
             })
           }
@@ -299,22 +462,29 @@ export function Settings() {
           max={600}
           value={settings.max_recording_seconds}
           onChange={(e) =>
-            setSettings({
-              ...settings,
+            updateSettings({
               max_recording_seconds: Number.parseInt(e.target.value, 10) || 120,
-            })
+            }, { debounce: true })
           }
         />
       </div>
 
       <div className="settings-section">
         <div className="settings-toggle">
+          <span>Realtime transcription</span>
+          <input
+            type="checkbox"
+            checked={settings.realtime_transcription}
+            onChange={(e) => setRealtimeMode(e.target.checked)}
+          />
+        </div>
+        <div className="settings-toggle">
           <span>Auto-paste after transcription</span>
           <input
             type="checkbox"
             checked={settings.auto_paste}
             onChange={(e) =>
-              setSettings({ ...settings, auto_paste: e.target.checked })
+              updateSettings({ auto_paste: e.target.checked })
             }
           />
         </div>
@@ -324,7 +494,7 @@ export function Settings() {
             type="checkbox"
             checked={settings.lower_volume_while_recording}
             onChange={(e) =>
-              setSettings({ ...settings, lower_volume_while_recording: e.target.checked })
+              updateSettings({ lower_volume_while_recording: e.target.checked })
             }
           />
         </div>
@@ -334,7 +504,7 @@ export function Settings() {
             type="checkbox"
             checked={settings.translate_to_english}
             onChange={(e) =>
-              setSettings({ ...settings, translate_to_english: e.target.checked })
+              updateSettings({ translate_to_english: e.target.checked })
             }
           />
         </div>
@@ -356,10 +526,6 @@ export function Settings() {
           />
         </div>
       </div>
-
-      <button className="btn-primary" onClick={() => void save()} disabled={saving}>
-        {saving ? "Saving…" : saved ? "Saved!" : "Save Settings"}
-      </button>
 
       <div className="help-section">
         <p style={{ fontSize: 12, color: "#8e8e93", marginBottom: 8 }}>

--- a/src/hooks/useTauriEvents.ts
+++ b/src/hooks/useTauriEvents.ts
@@ -2,9 +2,16 @@ import { useEffect, useEffectEvent } from "react";
 import { listen, type UnlistenFn } from "@tauri-apps/api/event";
 
 export type AppEvent =
-  | { type: "recording-started" }
-  | { type: "recording-stopped" }
+  | {
+      type: "recording-started";
+      realtime: boolean;
+      autoPaste: boolean;
+      targetCaptured: boolean;
+    }
+  | { type: "recording-stopped"; finalizing: boolean; realtime: boolean }
   | { type: "transcription-complete"; text: string }
+  | { type: "realtime-transcription"; text: string; fullText: string }
+  | { type: "realtime-mode-updated"; armed: boolean; active: boolean }
   | { type: "transcription-error"; message: string }
   | { type: "download-progress"; model: string; percent: number }
   | { type: "hotkey-start" }
@@ -22,10 +29,39 @@ export function useTauriEvents(handler: Handler) {
 
     const setup = async () => {
       const subscriptions = await Promise.all([
-        listen("recording-started", () => onEvent({ type: "recording-started" })),
-        listen("recording-stopped", () => onEvent({ type: "recording-stopped" })),
+        listen<{ realtime?: boolean; auto_paste?: boolean; target_captured?: boolean }>(
+          "recording-started",
+          (e) =>
+            onEvent({
+              type: "recording-started",
+              realtime: Boolean(e.payload?.realtime),
+              autoPaste: Boolean(e.payload?.auto_paste),
+              targetCaptured: Boolean(e.payload?.target_captured),
+            })
+        ),
+        listen<{ finalizing?: boolean; realtime?: boolean }>("recording-stopped", (e) =>
+          onEvent({
+            type: "recording-stopped",
+            finalizing: e.payload?.finalizing ?? true,
+            realtime: Boolean(e.payload?.realtime),
+          })
+        ),
         listen<{ text: string }>("transcription-complete", (e) =>
           onEvent({ type: "transcription-complete", text: e.payload.text })
+        ),
+        listen<{ text: string; full_text: string }>("realtime-transcription", (e) =>
+          onEvent({
+            type: "realtime-transcription",
+            text: e.payload.text,
+            fullText: e.payload.full_text,
+          })
+        ),
+        listen<{ armed: boolean; active: boolean }>("realtime-mode-updated", (e) =>
+          onEvent({
+            type: "realtime-mode-updated",
+            armed: e.payload.armed,
+            active: e.payload.active,
+          })
         ),
         listen<{ message: string }>("transcription-error", (e) =>
           onEvent({ type: "transcription-error", message: e.payload.message })

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -11,7 +11,7 @@ body {
 .overlay-root {
   display: flex;
   justify-content: center;
-  align-items: center;
+  align-items: flex-start;
   width: 100vw;
   height: 100vh;
   pointer-events: none;
@@ -21,15 +21,130 @@ body {
   display: flex;
   align-items: center;
   gap: 5px;
-  padding: 3px 10px;
+  padding: 5px 10px;
   background: rgba(30, 30, 30, 0.88);
   border-radius: 9999px;
   backdrop-filter: blur(8px);
   -webkit-backdrop-filter: blur(8px);
+  cursor: grab;
+  pointer-events: auto;
+}
+
+.overlay-pill:active {
+  cursor: grabbing;
+}
+
+.overlay-row {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 5px;
 }
 
 .overlay-recording {
   animation: pill-glow 2s ease-in-out infinite;
+}
+
+.overlay-recording-live {
+  flex-direction: column;
+  align-items: stretch;
+  gap: 4px;
+  width: min(340px, calc(100vw - 16px));
+  border-radius: 12px;
+}
+
+.overlay-partial {
+  max-width: 320px;
+  max-height: 202px;
+  color: #fff;
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  font-size: 11px;
+  line-height: 1.25;
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+  overflow-y: auto;
+  opacity: 0.9;
+  scrollbar-width: none;
+}
+
+.overlay-partial::-webkit-scrollbar {
+  display: none;
+}
+
+.overlay-partial-pending {
+  color: rgba(255, 255, 255, 0.72);
+}
+
+.overlay-mode-badge,
+.overlay-target-badge,
+.overlay-mode-toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  height: 16px;
+  border-radius: 9999px;
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  font-size: 9px;
+  font-weight: 700;
+  line-height: 1;
+  text-transform: uppercase;
+  white-space: nowrap;
+}
+
+.overlay-mode-badge,
+.overlay-target-badge {
+  padding: 0 6px;
+}
+
+.overlay-mode-badge-live {
+  background: rgba(16, 185, 129, 0.18);
+  border: 1px solid rgba(16, 185, 129, 0.55);
+  color: #d1fae5;
+}
+
+.overlay-mode-badge-disabled {
+  background: rgba(142, 142, 147, 0.14);
+  border: 1px solid rgba(142, 142, 147, 0.4);
+  color: #d1d1d6;
+}
+
+.overlay-target-badge-ready {
+  background: rgba(10, 132, 255, 0.18);
+  border: 1px solid rgba(10, 132, 255, 0.55);
+  color: #dbeafe;
+}
+
+.overlay-target-badge-muted {
+  background: rgba(255, 159, 10, 0.14);
+  border: 1px solid rgba(255, 159, 10, 0.4);
+  color: #ffe8b5;
+}
+
+.overlay-mode-badge-live::before {
+  content: "";
+  width: 5px;
+  height: 5px;
+  border-radius: 50%;
+  background: #34d399;
+  animation: pulse 1.2s ease-in-out infinite;
+}
+
+.overlay-mode-toggle {
+  pointer-events: auto;
+  padding: 0 7px;
+  background: rgba(255, 255, 255, 0.12);
+  border: 1px solid rgba(255, 255, 255, 0.22);
+  color: #fff;
+  cursor: pointer;
+}
+
+.overlay-mode-toggle:hover {
+  background: rgba(255, 255, 255, 0.2);
+}
+
+.overlay-mode-toggle:disabled {
+  cursor: default;
+  opacity: 0.55;
 }
 
 @keyframes pill-glow {
@@ -159,6 +274,22 @@ body {
   overflow-y: auto;
 }
 
+.settings-header-meta {
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+  color: #8e8e93;
+  font-size: 12px;
+}
+
+.settings-save-status {
+  color: #d1d1d6;
+}
+
+.settings-save-status-saved {
+  color: #10b981;
+}
+
 .accessibility-banner {
   background: rgba(255, 179, 0, 0.12);
   border: 1px solid rgba(255, 179, 0, 0.4);
@@ -174,6 +305,67 @@ body {
 
 .settings-section {
   margin-bottom: 24px;
+}
+
+.recording-control {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  padding: 14px 16px;
+  background: #242426;
+  border: 1px solid #343438;
+  border-radius: 8px;
+}
+
+.recording-mode-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+
+.recording-helper {
+  margin: 0 0 8px;
+  color: #8e8e93;
+  font-size: 12px;
+  line-height: 1.35;
+}
+
+.mode-pill {
+  display: inline-flex;
+  align-items: center;
+  height: 20px;
+  padding: 0 8px;
+  border-radius: 9999px;
+  font-size: 11px;
+  font-weight: 700;
+  appearance: none;
+  cursor: default;
+}
+
+.mode-pill-armed {
+  background: rgba(16, 185, 129, 0.14);
+  color: #d1fae5;
+  border: 1px solid rgba(16, 185, 129, 0.45);
+}
+
+.mode-pill-disabled {
+  background: rgba(142, 142, 147, 0.14);
+  color: #d1d1d6;
+  border: 1px solid rgba(142, 142, 147, 0.35);
+}
+
+button.mode-pill {
+  cursor: pointer;
+}
+
+button.mode-pill:hover {
+  filter: brightness(1.15);
+}
+
+button.mode-pill:disabled {
+  cursor: not-allowed;
+  opacity: 0.65;
 }
 
 .settings-label {


### PR DESCRIPTION
## Summary

Adds an opt-in realtime dictation mode on top of the existing batch transcription flow.

While recording, the app transcribes short Whisper chunks, shows partial text in the overlay, and can insert committed chunks into the captured target when Auto-paste is enabled. Batch transcription remains the fallback path, and realtime mode skips the duplicate final transcription once live output has already been produced.

This also includes UI and flow improvements around realtime use:
- Settings autosave instead of manual save
- Realtime controls in Settings and the recording overlay
- Overlay transcript display with wrapped, growing text
- Draggable overlay bubble
- Recording status badges for realtime/live typing state
- Settings Start/Stop recording flow with delayed target capture
- Menu-bar click behavior improvements

## Verification

- `corepack pnpm build`
- `cargo check --manifest-path src-tauri/Cargo.toml --no-default-features`
- `cargo check --manifest-path src-tauri/Cargo.toml --no-default-features --features metal`
- `cargo test --manifest-path src-tauri/Cargo.toml`

## Notes

macOS is the primary validated path for live typing. Windows/Linux realtime chunk insertion still needs dedicated QA around focus capture, clipboard behavior, and desktop/session differences.